### PR TITLE
chore: remove output when no kubeconfig-content is found in environment

### DIFF
--- a/pkg/kubectl/kubectl_test.go
+++ b/pkg/kubectl/kubectl_test.go
@@ -26,7 +26,7 @@ func TestNew(t *testing.T) {
 	assert.Equal(t, "missing", k.(*kubectl).args["context"])
 	assert.Equal(t, "dev", k.(*kubectl).args["namespace"])
 	assert.Equal(t, "", out.String())
-	assert.Equal(t, "failed to get kubeconfig from environment\n", eout.String())
+	assert.Equal(t, "", eout.String())
 }
 
 func TestNew_NoNamespace(t *testing.T) {
@@ -100,7 +100,7 @@ func TestKubectl_Environment(t *testing.T) {
 
 	assert.Equal(t, "", k.(*kubectl).args["namespace"])
 	assert.Equal(t, "", out.String())
-	assert.Equal(t, "failed to get kubeconfig from environment\n", eout.String())
+	assert.Equal(t, "", eout.String())
 }
 
 func TestKubectl_DeploymentExistsTrue(t *testing.T) {
@@ -117,7 +117,7 @@ func TestKubectl_DeploymentExistsTrue(t *testing.T) {
 	assert.Equal(t, 1, len(calls))
 	assert.Equal(t, []string{"get", "deployment", "image", "--context", "missing", "--namespace", "default"}, calls[0])
 	assert.Equal(t, "kubectl --context missing --namespace default get deployment image\n", out.String())
-	assert.Equal(t, "failed to get kubeconfig from environment\n", eout.String())
+	assert.Equal(t, "", eout.String())
 }
 
 func TestKubectl_DeploymentExistsFalse(t *testing.T) {
@@ -135,7 +135,7 @@ func TestKubectl_DeploymentExistsFalse(t *testing.T) {
 	assert.Equal(t, 1, len(calls))
 	assert.Equal(t, []string{"get", "deployment", "image", "--context", "missing", "--namespace", "default"}, calls[0])
 	assert.Equal(t, "kubectl --context missing --namespace default get deployment image\n", out.String())
-	assert.Equal(t, "failed to get kubeconfig from environment\n", eout.String())
+	assert.Equal(t, "", eout.String())
 }
 
 func TestKubectl_RolloutStatusSuccess(t *testing.T) {
@@ -152,7 +152,7 @@ func TestKubectl_RolloutStatusSuccess(t *testing.T) {
 	assert.Equal(t, 1, len(calls))
 	assert.Equal(t, []string{"rollout", "status", "deployment", "image", "--context", "missing", "--namespace", "default", "--timeout", "2m0s"}, calls[0])
 	assert.Equal(t, "kubectl --context missing --namespace default rollout status deployment --timeout=2m image\n", out.String())
-	assert.Equal(t, "failed to get kubeconfig from environment\n", eout.String())
+	assert.Equal(t, "", eout.String())
 }
 
 func TestKubectl_RolloutStatusFailure(t *testing.T) {
@@ -170,7 +170,7 @@ func TestKubectl_RolloutStatusFailure(t *testing.T) {
 	assert.Equal(t, 1, len(calls))
 	assert.Equal(t, []string{"rollout", "status", "deployment", "image", "--context", "missing", "--namespace", "default", "--timeout", "2m0s"}, calls[0])
 	assert.Equal(t, "kubectl --context missing --namespace default rollout status deployment --timeout=2m image\n", out.String())
-	assert.Equal(t, "failed to get kubeconfig from environment\n", eout.String())
+	assert.Equal(t, "", eout.String())
 }
 
 func TestKubectl_RolloutStatusFatal(t *testing.T) {
@@ -191,7 +191,7 @@ func TestKubectl_RolloutStatusFatal(t *testing.T) {
 	assert.Equal(t, 1, len(calls))
 	assert.Equal(t, []string{"rollout", "status", "deployment", "image", "--context", "missing", "--namespace", "default", "--timeout", "3m0s"}, calls[0])
 	assert.Equal(t, "kubectl --context missing --namespace default rollout status deployment --timeout=3m image\n", out.String())
-	assert.Equal(t, "failed to get kubeconfig from environment\n", eout.String())
+	assert.Equal(t, "", eout.String())
 }
 
 func TestKubectl_KubeconfigSet(t *testing.T) {
@@ -202,14 +202,25 @@ func TestKubectl_KubeconfigSet(t *testing.T) {
     cluster: k8s.prod
     user: user@example.org
 `
-	defer pkg.SetEnv(envKubeConfigContent, yaml)()
+	defer pkg.SetEnv(envKubeconfigContent, yaml)()
 	k := New(&config.Environment{}, out, eout)
 
-	kubeConfigFile := filepath.Join(k.(*kubectl).tempDir, "kubeconfig")
-	fileContent, err := ioutil.ReadFile(kubeConfigFile)
+	kubeconfigFile := filepath.Join(k.(*kubectl).tempDir, "kubeconfig")
+	fileContent, err := ioutil.ReadFile(kubeconfigFile)
 	assert.NoError(t, err)
 	assert.Equal(t, "contexts:\n- context:\n    cluster: k8s.prod\n    user: user@example.org\n", string(fileContent))
-	assert.Equal(t, kubeConfigFile, k.(*kubectl).args["kubeconfig"])
+	assert.Equal(t, kubeconfigFile, k.(*kubectl).args["kubeconfig"])
+	k.Cleanup()
+}
+
+func TestKubectl_KubeconfigSetToEmptyValue(t *testing.T) {
+	out := &bytes.Buffer{}
+	eout := &bytes.Buffer{}
+	yaml := ``
+	defer pkg.SetEnv(envKubeconfigContent, yaml)()
+	k := New(&config.Environment{}, out, eout)
+
+	assert.Equal(t, "", k.(*kubectl).args["kubeconfig"])
 	k.Cleanup()
 }
 
@@ -221,21 +232,21 @@ func TestKubectl_KubeconfigBase64Set(t *testing.T) {
     cluster: k8s.prod
     user: user@example.org
 `
-	defer pkg.SetEnv(envKubeConfigContentBase64, base64.StdEncoding.EncodeToString([]byte(yaml)))()
+	defer pkg.SetEnv(envKubeconfigContentBase64, base64.StdEncoding.EncodeToString([]byte(yaml)))()
 	k := New(&config.Environment{}, out, eout)
 
-	kubeConfigFile := filepath.Join(k.(*kubectl).tempDir, "kubeconfig")
-	fileContent, err := ioutil.ReadFile(kubeConfigFile)
+	kubeconfigFile := filepath.Join(k.(*kubectl).tempDir, "kubeconfig")
+	fileContent, err := ioutil.ReadFile(kubeconfigFile)
 	assert.NoError(t, err)
 	assert.Equal(t, "contexts:\n- context:\n    cluster: k8s.prod\n    user: user@example.org\n", string(fileContent))
-	assert.Equal(t, kubeConfigFile, k.(*kubectl).args["kubeconfig"])
+	assert.Equal(t, kubeconfigFile, k.(*kubectl).args["kubeconfig"])
 	k.Cleanup()
 }
 
 func TestKubectl_KubeconfigInvalidBase64Set(t *testing.T) {
 	out := &bytes.Buffer{}
 	eout := &bytes.Buffer{}
-	defer pkg.SetEnv(envKubeConfigContentBase64, "äö")()
+	defer pkg.SetEnv(envKubeconfigContentBase64, "äö")()
 	k := New(&config.Environment{}, out, eout)
 	assert.Equal(t, "Failed to decode content: illegal base64 data at input byte 0\n", eout.String())
 
@@ -272,7 +283,7 @@ func TestKubectl_DeploymentEvents_Error(t *testing.T) {
 	assert.Equal(t, 1, len(calls))
 	assert.Equal(t, []string{"describe", "deployment", "image", "--context", "missing", "--namespace", "default", "--show-events", "true"}, calls[0])
 	assert.Equal(t, "kubectl --context missing --namespace default describe deployment image --show-events=true\n", out.String())
-	assert.Equal(t, "failed to get kubeconfig from environment\n", eout.String())
+	assert.Equal(t, "", eout.String())
 }
 
 func TestKubectl_DeploymentEvents_NoEvents(t *testing.T) {
@@ -295,7 +306,7 @@ Events:          <none>
 	assert.Equal(t, 1, len(calls))
 	assert.Equal(t, []string{"describe", "deployment", "image", "--context", "missing", "--namespace", "default", "--show-events", "true"}, calls[0])
 	assert.Equal(t, "kubectl --context missing --namespace default describe deployment image --show-events=true\n", out.String())
-	assert.Equal(t, "failed to get kubeconfig from environment\n", eout.String())
+	assert.Equal(t, "", eout.String())
 }
 
 func TestKubectl_DeploymentEvents_SomeEvents(t *testing.T) {
@@ -324,7 +335,7 @@ Events:
 	assert.Equal(t, 1, len(calls))
 	assert.Equal(t, []string{"describe", "deployment", "image", "--context", "missing", "--namespace", "default", "--show-events", "true"}, calls[0])
 	assert.Equal(t, "kubectl --context missing --namespace default describe deployment image --show-events=true\n", out.String())
-	assert.Equal(t, "failed to get kubeconfig from environment\n", eout.String())
+	assert.Equal(t, "", eout.String())
 }
 
 func TestKubectl_PodEvents_Error(t *testing.T) {
@@ -343,7 +354,7 @@ func TestKubectl_PodEvents_Error(t *testing.T) {
 	assert.Equal(t, 1, len(calls))
 	assert.Equal(t, []string{"describe", "pods", "--context", "missing", "--namespace", "default", "--show-events", "true", "--selector", "app=image"}, calls[0])
 	assert.Equal(t, "kubectl --context missing --namespace default describe pods -l app=image --show-events=true\n", out.String())
-	assert.Equal(t, "failed to get kubeconfig from environment\n", eout.String())
+	assert.Equal(t, "", eout.String())
 }
 
 func TestKubectl_PodEvents_NoEvents(t *testing.T) {
@@ -366,7 +377,7 @@ Events:          <none>
 	assert.Equal(t, 1, len(calls))
 	assert.Equal(t, []string{"describe", "pods", "--context", "missing", "--namespace", "default", "--show-events", "true", "--selector", "app=image"}, calls[0])
 	assert.Equal(t, "kubectl --context missing --namespace default describe pods -l app=image --show-events=true\n", out.String())
-	assert.Equal(t, "failed to get kubeconfig from environment\n", eout.String())
+	assert.Equal(t, "", eout.String())
 }
 
 func TestKubectl_PodEvents_SomeEvents(t *testing.T) {
@@ -394,7 +405,7 @@ Events:
 	assert.Equal(t, 1, len(calls))
 	assert.Equal(t, []string{"describe", "pods", "--context", "missing", "--namespace", "default", "--show-events", "true", "--selector", "app=image"}, calls[0])
 	assert.Equal(t, "kubectl --context missing --namespace default describe pods -l app=image --show-events=true\n", out.String())
-	assert.Equal(t, "failed to get kubeconfig from environment\n", eout.String())
+	assert.Equal(t, "", eout.String())
 }
 
 var calls [][]string
@@ -402,7 +413,7 @@ var cmdError *string
 var events *string
 var fatal = false
 
-func mockCmd(in io.Reader, out, err io.Writer) *cobra.Command {
+func mockCmd(_ io.Reader, out, _ io.Writer) *cobra.Command {
 	var ctx, ns, file *string
 	var timeout *time.Duration
 	var showEvents *bool


### PR DESCRIPTION
also a few renamed vars