### PR TITLE
feat: support base64 encoded and plain text config content

### DIFF
--- a/pkg/kubectl/kubectl_test.go
+++ b/pkg/kubectl/kubectl_test.go
@@ -239,7 +239,7 @@ func TestKubectl_KubeconfigBase64Set(t *testing.T) {
     cluster: k8s.prod
     user: user@example.org
 `
-	defer pkg.SetEnv(envKubeconfigContentBase64, base64.StdEncoding.EncodeToString([]byte(yaml)))()
+	defer pkg.SetEnv(envKubeconfigContent, base64.StdEncoding.EncodeToString([]byte(yaml)))()
 	k := New(&config.Target{}, out, eout)
 
 	kubeconfigFile := filepath.Join(k.(*kubectl).tempDir, "kubeconfig")
@@ -247,16 +247,6 @@ func TestKubectl_KubeconfigBase64Set(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "contexts:\n- context:\n    cluster: k8s.prod\n    user: user@example.org\n", string(fileContent))
 	assert.Equal(t, kubeconfigFile, k.(*kubectl).args["kubeconfig"])
-	k.Cleanup()
-}
-
-func TestKubectl_KubeconfigInvalidBase64Set(t *testing.T) {
-	out := &bytes.Buffer{}
-	eout := &bytes.Buffer{}
-	defer pkg.SetEnv(envKubeconfigContentBase64, "äö")()
-	k := New(&config.Target{}, out, eout)
-	assert.Equal(t, "Failed to decode content: illegal base64 data at input byte 0\n", eout.String())
-
 	k.Cleanup()
 }
 


### PR DESCRIPTION
Tries to decode the _CONTENT env variables from base64 first and if that fails
revert to plain text and then parse.
More verbose logging is needed, but need to implement verbose 'globally' so not in this PR.

Closes #31 - BASE64 variant not supported anymore.
Closes #32 - since it's not needed anymore.