### PR TITLE
chore: retry promote push

### DIFF
--- a/pkg/promote/promote.go
+++ b/pkg/promote/promote.go
@@ -94,7 +94,16 @@ func Promote(dir, name, timestamp string, target *config.Gitops, args Args, gitC
 		}
 		err = commitAndPush(target, keys, name, buffer, args, gitConfig)
 		if err != nil {
-			return err
+			if strings.HasPrefix(err.Error(), git.ErrNonFastForwardUpdate.Error()) {
+				// Retry one more time
+				log.Infof("Non fast-forward error during push, retrying")
+				err = commitAndPush(target, keys, name, buffer, args, gitConfig)
+				if err != nil {
+					return err
+				}
+			} else {
+				return err
+			}
 		}
 	} else {
 		err := os.WriteFile(args.Out, buffer.Bytes(), 0666)


### PR DESCRIPTION
If another commit has been pushed before promote can finish
processing and push to the remote target it will fail.
The git library doesn't support rebasing pulls so we just
discard the work and retry with a new fresh commit