### PR TITLE
feat: support for in-cluster deployment

### DIFF
--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -79,6 +79,10 @@ func DoDeploy(dir string, info version.Info, osArgs ...string) int {
 			log.Errorf("context is mandatory, not found in configuration for %s and not passed as parameter\n", deployArgs.Target)
 			return -5
 		}
+		if env.Context == "in-cluster" {
+			log.Info("Using empty context for in-cluster deploy\n")
+			env.Context = ""
+		}
 		if deployArgs.Namespace != "" {
 			env.Namespace = deployArgs.Namespace
 		}

--- a/www/docs/config/targets.md
+++ b/www/docs/config/targets.md
@@ -25,6 +25,9 @@ The `KUBECONFIG_CONTENT` environment variable (probably most useful in CI/CD pip
 content of a "kubeconfig" file. If set, buildtools will create a temporary file with that content to use as the `kubeconfig` value.
 `KUBECONFIG_CONTENT` can be either a base64 encoded string or plain text.
 
+When deploying from inside a cluster, set `context: in-cluster` and make sure that the Pod has the appropriate
+permissions.
+
 **Note:** the `kubeconfig` parameter in config file overrides both the `KUBECONFIG` and `KUBECONFIG_CONTENT` environment
 variables if set.
 


### PR DESCRIPTION
Add option to set context to in-cluster and use the 'kubeconfig' inside the Pod