### PR TITLE
fix: update release arguments in check_release workflow action

### DIFF
--- a/.github/workflows/check_release.yaml
+++ b/.github/workflows/check_release.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
-          args: release --skip-validate --rm-dist --skip-publish
+          args: release --skip=validate,publish --clean
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
This commit updates the release arguments in the check_release workflow action
to use non-deprecated values.