### PR TITLE
fix(go.mod): update Go version to 1.23.5 for compatibility

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildtool/build-tools
 
-go 1.23.3
+go 1.23.5
 
 require (
 	dario.cat/mergo v1.0.1


### PR DESCRIPTION
Updates the Go version from 1.23.3 to 1.23.5 to ensure compatibility 
with dependencies and improve stability. This change addresses 
potential issues and leverages performance enhancements in the 
latest version.