### PR TITLE
ci: update Go version to 1.24.0 for compatibility improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildtool/build-tools
 
-go 1.23.5
+go 1.24.0
 
 require (
 	dario.cat/mergo v1.0.1


### PR DESCRIPTION
Updates the Go version in the go.mod file from 1.23.5 to 1.24.0 to 
leverage new features and performance enhancements. This change 
ensures compatibility with the latest dependencies and toolsets.