### PR TITLE
chore(deps): update Go version to 1.24.2 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildtool/build-tools
 
-go 1.24.0
+go 1.24.2
 
 require (
 	dario.cat/mergo v1.0.1


### PR DESCRIPTION
Updates the Go version in go.mod from 1.24.0 to 1.24.2 to ensure 
compatibility with the latest features and security improvements.