### PR TITLE
fix(build): handle error comparison correctly in main

### DIFF
--- a/cmd/build/build.go
+++ b/cmd/build/build.go
@@ -23,6 +23,7 @@
 package main
 
 import (
+	"errors"
 	"os"
 
 	"github.com/apex/log"
@@ -55,7 +56,7 @@ func main() {
 	}
 	err := args.ParseArgs(dir, os.Args[1:], info, &buildArgs)
 	if err != nil {
-		if err != args.ErrDone {
+		if !errors.Is(err, args.ErrDone) {
 			exitFunc(-1)
 			return
 		} else {


### PR DESCRIPTION
Add error package import to enable proper error comparison.  
Update the error handling in the main function to use `errors.Is` for  
comparing the error with `args.ErrDone`, ensuring accurate error  
detection and handling in the build process.