### PR TITLE
feat(build): add support to use StdIn for reading Dockerfile content

### DIFF
--- a/pkg/args/args.go
+++ b/pkg/args/args.go
@@ -25,6 +25,8 @@ package args
 import (
 	"bytes"
 	"errors"
+	"io"
+	"os"
 
 	"github.com/alecthomas/kong"
 	"github.com/apex/log"
@@ -38,6 +40,7 @@ type Globals struct {
 	Version VersionFlag `name:"version" help:"Print args information and exit"`
 	Verbose VerboseFlag `short:"v" help:"Enable verbose mode"`
 	Config  ConfigFlag  `help:"Print parsed config and exit"`
+	StdIn   io.Reader   `kong:"-"`
 }
 
 type VersionFlag string
@@ -77,6 +80,11 @@ func (v VerboseFlag) Decode(ctx *kong.DecodeContext) error { return nil }
 func (v VerboseFlag) IsBool() bool                         { return true }
 func (v VerboseFlag) BeforeApply(*kong.Kong, kong.Vars) error {
 	log.SetLevel(log.DebugLevel)
+	return nil
+}
+
+func (v *Globals) AfterApply() error {
+	v.StdIn = os.Stdin
 	return nil
 }
 

--- a/www/docs/commands/build.md
+++ b/www/docs/commands/build.md
@@ -5,7 +5,7 @@ conventions no additional flags are needed, but the following flags are availabl
 
 | Flag                                 | Description                                                                                                                                             |
 |:-------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `--file`,`-f` `<path to Dockerfile>` | Used to override the default `Dockerfile` location (which is `$PWD`)                                                                                    |
+| `--file`,`-f` `<path to Dockerfile>` | Used to override the default `Dockerfile` location (which is `$PWD`), or `-` to read from `stdin                                                        |
 | `--no-login`                         | Disables login to docker registry (good for local testing)                                                                                              |
 | `--no-pull`                          | Disables pulling of remote images if they already exist (good for local testing)                                                                        |
 | `--build-arg key=value`              | Additional Docker [build-arg](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg)                         |
@@ -21,8 +21,8 @@ The
 following [build-arg](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg)
 are automatically made available:
 
-|      Arg    |                   Value                                |
-| :---------- | :----------------------------------------------------- |
+| Arg         | Value                                                  |
+|:------------|:-------------------------------------------------------|
 | `CI_COMMIT` | The commit being built as exposed by [CI](../ci/ci.md) |
 | `CI_BRANCH` | The branch being built as exposed by [CI](../ci/ci.md) |
 


### PR DESCRIPTION
Implement support for reading the Dockerfile content from stdin when the 
Dockerfile is specified as "-". Introduce helper methods in the Args 
struct to streamline determining the Dockerfile name and checking if 
it is from stdin. Update the build function accordingly to read the 
Dockerfile content conditionally. Enhance tests to cover cases for 
empty and stdin Dockerfile scenarios, ensuring robust error handling.