### PR TITLE
chore(deps): update pre-commit hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -33,7 +33,7 @@ repos:
           - --allow-multiple-documents
       - id: check-added-large-files
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v9.4.0
+    rev: v9.22.0
     hooks:
       - id: commitlint
         stages: [commit-msg]
@@ -45,11 +45,11 @@ repos:
       - id: go-mod-tidy
       - id: go-imports
   - repo: https://github.com/lietu/go-pre-commit
-    rev: v0.0.1
+    rev: v0.1.0
     hooks:
       - id: go-test
   #      - id: gofumpt
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.50.1
+    rev: v2.1.5
     hooks:
       - id: golangci-lint


### PR DESCRIPTION
Upgrade the versions of several pre-commit hooks to their latest releases.  
This enhances compatibility, incorporates bug fixes, and ensures the  
latest features are available for improved code quality and linting.  
Notably, updates include commitlint, pre-commit hooks, and  
golangci-lint, ensuring optimal functionality.