### PR TITLE
docs: update Gitlab CI link and capitalize TeamCity

### DIFF
--- a/www/docs/ci/ci.md
+++ b/www/docs/ci/ci.md
@@ -13,7 +13,7 @@ The following variables are checked to determine which CI/CD tool that we run un
 
 
 [Buildkite]: https://buildkite.com
-[Gitlab CI]: https://docs.gitlab.com/ce/ci
+[Gitlab CI]: https://docs.gitlab.com/ci/
 [Github Actions]: https://github.com/features/actions
-[teamcity]: https://www.jetbrains.com/teamcity
+[TeamCity]: https://www.jetbrains.com/teamcity
 [azure devops]: https://azure.microsoft.com/en-us/services/devops/pipelines/

--- a/www/docs/ci/ci.md
+++ b/www/docs/ci/ci.md
@@ -16,4 +16,4 @@ The following variables are checked to determine which CI/CD tool that we run un
 [Gitlab CI]: https://docs.gitlab.com/ci/
 [Github Actions]: https://github.com/features/actions
 [TeamCity]: https://www.jetbrains.com/teamcity
-[azure devops]: https://azure.microsoft.com/en-us/services/devops/pipelines/
+[Azure Devops]: https://azure.microsoft.com/en-us/products/devops


### PR DESCRIPTION
Update the Gitlab CI documentation link to use the correct URL.  
Capitalize "TeamCity" for consistency with other CI/CD tool names.