### PR TITLE
docs: update more links to Azure DevOps and GitLab CI documentation

### DIFF
--- a/www/docs/ci/azure.md
+++ b/www/docs/ci/azure.md
@@ -25,4 +25,4 @@ jobs:
     condition: succeeded()
 ````
 
-[azure devops]: https://azure.microsoft.com/en-us/services/devops/pipelines/
+[azure devops]: https://azure.microsoft.com/en-us/products/devops

--- a/www/docs/ci/gitlab.md
+++ b/www/docs/ci/gitlab.md
@@ -42,4 +42,4 @@ deploy-to-prod:
     - main
 ````
 
-[Gitlab CI]: https://docs.gitlab.com/ce/ci
+[Gitlab CI]: https://docs.gitlab.com/ci


### PR DESCRIPTION
Updates the Azure DevOps link to point to the products page and  
the GitLab CI link to the correct section of the documentation.  
These changes ensure users access the most relevant and accurate  
resources for CI/CD integration.