### PR TITLE
ci: remove conditional check for main branch in deploy step

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -28,7 +28,6 @@ jobs:
           ./bin/htmltest -c htmltest.yaml
 
       - name: Deploy site
-        if: startsWith(github.ref, 'refs/heads/main')
         uses: peaceiris/actions-gh-pages@v4
         with:
           personal_token: ${{ secrets.ACTIONS_DEPLOY_KEY }}


### PR DESCRIPTION
Removes the conditional check for deployment only on the main branch 
in the GitHub Actions workflow. This change enables the deployment 
process to trigger for all branches, improving the workflow's 
flexibility and allowing for quicker iterations during development.