### PR TITLE
chore: remove pull_request event from release workflow

### DIFF
--- a/.github/workflows/check_release.yaml
+++ b/.github/workflows/check_release.yaml
@@ -3,8 +3,6 @@ name: check release
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
 jobs:
   check_release:


### PR DESCRIPTION
This update removes the pull_request trigger from the 
check_release workflow. The change aims to streamline 
the workflow by only responding to pushes on the main 
branch, simplifying the process and reducing unnecessary 
checks during pull requests.