### PR TITLE
feat: add go-fumpt to pre-commit hooks and update code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,4 +50,5 @@ repos:
       - id: go-mod-tidy
       - id: go-imports
       - id: go-test-mod
+      - id: go-fumpt
       - id: golangci-lint-mod

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -58,7 +58,7 @@ func TestDeploy_BrokenConfig(t *testing.T) {
 	defer func() { _ = os.RemoveAll(name) }()
 	yaml := `ci: []
 `
-	_ = os.WriteFile(filepath.Join(name, ".buildtools.yaml"), []byte(yaml), 0777)
+	_ = os.WriteFile(filepath.Join(name, ".buildtools.yaml"), []byte(yaml), 0o777)
 
 	err := os.Chdir(name)
 	assert.NoError(t, err)
@@ -99,7 +99,7 @@ targets:
     context: missing
     namespace: none
 `
-	_ = os.WriteFile(filepath.Join(name, ".buildtools.yaml"), []byte(yaml), 0777)
+	_ = os.WriteFile(filepath.Join(name, ".buildtools.yaml"), []byte(yaml), 0o777)
 
 	err := os.Chdir(name)
 	assert.NoError(t, err)
@@ -126,7 +126,7 @@ targets:
     context: missing
     namespace: none
 `
-	_ = os.WriteFile(filepath.Join(name, ".buildtools.yaml"), []byte(yaml), 0777)
+	_ = os.WriteFile(filepath.Join(name, ".buildtools.yaml"), []byte(yaml), 0o777)
 
 	err := os.Chdir(name)
 	assert.NoError(t, err)
@@ -153,7 +153,7 @@ targets:
     context: missing
     namespace: none
 `
-	_ = os.WriteFile(filepath.Join(name, ".buildtools.yaml"), []byte(yaml), 0777)
+	_ = os.WriteFile(filepath.Join(name, ".buildtools.yaml"), []byte(yaml), 0o777)
 
 	err := os.Chdir(name)
 	assert.NoError(t, err)
@@ -180,7 +180,7 @@ targets:
     context: missing
     namespace: none
 `
-	_ = os.WriteFile(filepath.Join(name, ".buildtools.yaml"), []byte(yaml), 0777)
+	_ = os.WriteFile(filepath.Join(name, ".buildtools.yaml"), []byte(yaml), 0o777)
 
 	err := os.Chdir(name)
 	assert.NoError(t, err)
@@ -207,7 +207,7 @@ targets:
     context: missing
     namespace: none
 `
-	_ = os.WriteFile(filepath.Join(name, ".buildtools.yaml"), []byte(yaml), 0777)
+	_ = os.WriteFile(filepath.Join(name, ".buildtools.yaml"), []byte(yaml), 0o777)
 
 	err := os.Chdir(name)
 	assert.NoError(t, err)
@@ -230,7 +230,7 @@ targets:
     context: missing
     namespace: none
 `
-	_ = os.WriteFile(filepath.Join(name, ".buildtools.yaml"), []byte(yaml), 0777)
+	_ = os.WriteFile(filepath.Join(name, ".buildtools.yaml"), []byte(yaml), 0o777)
 
 	err := os.Chdir(name)
 	assert.NoError(t, err)

--- a/cmd/kubecmd/kubecmd_test.go
+++ b/cmd/kubecmd/kubecmd_test.go
@@ -63,7 +63,7 @@ targets:
     context: missing
     namespace: none
 `
-	_ = os.WriteFile(filepath.Join(name, ".buildtools.yaml"), []byte(yaml), 0777)
+	_ = os.WriteFile(filepath.Join(name, ".buildtools.yaml"), []byte(yaml), 0o777)
 
 	err := os.Chdir(name)
 	assert.NoError(t, err)
@@ -72,7 +72,6 @@ targets:
 	os.Args = []string{"kubecmd", "dummy"}
 	main()
 	assert.Equal(t, "kubectl --context missing --namespace none", out.(*bytes.Buffer).String())
-
 }
 
 func TestKubecmd_Output(t *testing.T) {
@@ -88,7 +87,7 @@ targets:
     context: local
     namespace: default
 `
-	_ = os.WriteFile(filepath.Join(name, ".buildtools.yaml"), []byte(yaml), 0777)
+	_ = os.WriteFile(filepath.Join(name, ".buildtools.yaml"), []byte(yaml), 0o777)
 
 	err := os.Chdir(name)
 	assert.NoError(t, err)

--- a/go.mod
+++ b/go.mod
@@ -4,68 +4,34 @@ go 1.24.2
 
 require (
 	dario.cat/mergo v1.0.2
-	github.com/MakeNowJust/heredoc v1.0.0 // indirect
-	github.com/ProtonMail/go-crypto v1.1.6 // indirect
-	github.com/alecthomas/kong v1.11.0
-	github.com/apex/log v1.9.0
-	github.com/caarlos0/env/v11 v11.3.1
-	github.com/chai2010/gettext-go v1.0.2 // indirect
-	github.com/containerd/console v1.0.4 // indirect
-	github.com/containerd/containerd v1.7.27
-	github.com/containerd/continuity v0.4.5 // indirect
-	github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f // indirect
-	github.com/go-errors/errors v1.4.2 // indirect
-	github.com/go-git/go-git/v5 v5.16.0
-	github.com/go-logr/logr v1.4.2 // indirect
-	github.com/go-openapi/jsonreference v0.20.2 // indirect
-	github.com/go-openapi/swag v0.23.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
-	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
-	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/kevinburke/ssh_config v1.2.0 // indirect
-	github.com/liamg/tml v0.7.0
-	github.com/mailru/easyjson v0.7.7 // indirect
-	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
-	github.com/moby/buildkit v0.22.0
-	github.com/moby/term v0.5.2 // indirect
-	github.com/morikuni/aec v1.0.0 // indirect
-	github.com/opencontainers/image-spec v1.1.1 // indirect
-	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
-	github.com/spf13/cobra v1.9.1
-	github.com/stretchr/testify v1.10.0
-	github.com/tonistiigi/fsutil v0.0.0-20250417144416-3f76f8130144
-	github.com/xanzy/ssh-agent v0.3.3 // indirect
-	github.com/xlab/treeprint v1.2.0 // indirect
-	gitlab.com/unboundsoftware/apex-mocks v0.2.0
-	golang.org/x/crypto v0.38.0
-	golang.org/x/net v0.40.0 // indirect
-	golang.org/x/oauth2 v0.28.0 // indirect
-	golang.org/x/sync v0.14.0
-	golang.org/x/sys v0.33.0 // indirect
-	golang.org/x/term v0.32.0 // indirect
-	golang.org/x/text v0.25.0 // indirect
-	google.golang.org/grpc v1.72.1
-	gopkg.in/yaml.v3 v3.0.1
-	k8s.io/client-go v0.33.1
-	k8s.io/klog/v2 v2.130.1
-	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
-	k8s.io/kubectl v0.33.1
-	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
-)
-
-require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.10.0
+	github.com/alecthomas/kong v1.11.0
+	github.com/apex/log v1.9.0
 	github.com/aws/aws-sdk-go-v2 v1.36.3
 	github.com/aws/aws-sdk-go-v2/config v1.29.14
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.44.0
 	github.com/aws/aws-sdk-go-v2/service/sts v1.33.19
-	github.com/caarlos0/env/v6 v6.10.1
+	github.com/caarlos0/env/v11 v11.3.1
+	github.com/containerd/containerd v1.7.27
 	github.com/docker/docker v28.1.1+incompatible
+	github.com/go-git/go-git/v5 v5.16.0
+	github.com/liamg/tml v0.7.0
+	github.com/moby/buildkit v0.22.0
 	github.com/opencontainers/go-digest v1.0.0
+	github.com/spf13/cobra v1.9.1
+	github.com/stretchr/testify v1.10.0
+	github.com/tonistiigi/fsutil v0.0.0-20250417144416-3f76f8130144
+	gitlab.com/unboundsoftware/apex-mocks v0.2.0
+	golang.org/x/crypto v0.38.0
 	golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6
+	golang.org/x/sync v0.14.0
+	google.golang.org/grpc v1.72.1
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/cli-runtime v0.33.1
+	k8s.io/client-go v0.33.1
+	k8s.io/klog/v2 v2.130.1
+	k8s.io/kubectl v0.33.1
 )
 
 require (
@@ -73,7 +39,9 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.1 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.4.2 // indirect
+	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
+	github.com/ProtonMail/go-crypto v1.1.6 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.67 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.30 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.34 // indirect
@@ -85,9 +53,12 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.1 // indirect
 	github.com/aws/smithy-go v1.22.2 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
+	github.com/chai2010/gettext-go v1.0.2 // indirect
 	github.com/cloudflare/circl v1.6.1 // indirect
+	github.com/containerd/console v1.0.4 // indirect
 	github.com/containerd/containerd/api v1.8.0 // indirect
 	github.com/containerd/containerd/v2 v2.0.5 // indirect
+	github.com/containerd/continuity v0.4.5 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
@@ -101,13 +72,18 @@ require (
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
+	github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f // indirect
 	github.com/fatih/camelcase v1.0.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
+	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.6.2 // indirect
+	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
+	github.com/go-openapi/jsonreference v0.20.2 // indirect
+	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/gofrs/flock v0.12.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
@@ -117,7 +93,9 @@ require (
 	github.com/google/gnostic-models v0.6.9 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
+	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.24.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
@@ -126,20 +104,27 @@ require (
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jonboulle/clockwork v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kevinburke/ssh_config v1.2.0 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/lithammer/dedent v1.1.0 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/locker v1.0.1 // indirect
 	github.com/moby/patternmatcher v0.6.0 // indirect
 	github.com/moby/spdystream v0.5.0 // indirect
 	github.com/moby/sys/signal v0.7.1 // indirect
+	github.com/moby/term v0.5.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
+	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
+	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pjbgf/sha1cd v0.3.2 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
@@ -148,6 +133,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.4.0 // indirect
+	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/shibumi/go-pathspec v1.3.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect
@@ -156,6 +142,8 @@ require (
 	github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea // indirect
 	github.com/tonistiigi/vt100 v0.0.0-20240514184818-90bafcd6abab // indirect
 	github.com/x448/float16 v0.8.4 // indirect
+	github.com/xanzy/ssh-agent v0.3.3 // indirect
+	github.com/xlab/treeprint v1.2.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.56.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.56.0 // indirect
@@ -166,6 +154,11 @@ require (
 	go.opentelemetry.io/otel/sdk v1.34.0 // indirect
 	go.opentelemetry.io/otel/trace v1.34.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.4.0 // indirect
+	golang.org/x/net v0.40.0 // indirect
+	golang.org/x/oauth2 v0.28.0 // indirect
+	golang.org/x/sys v0.33.0 // indirect
+	golang.org/x/term v0.32.0 // indirect
+	golang.org/x/text v0.25.0 // indirect
 	golang.org/x/time v0.11.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250218202821-56aae31c358a // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250218202821-56aae31c358a // indirect
@@ -178,11 +171,14 @@ require (
 	k8s.io/apimachinery v0.33.1 // indirect
 	k8s.io/component-base v0.33.1 // indirect
 	k8s.io/component-helpers v0.33.1 // indirect
+	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
 	k8s.io/metrics v0.33.1 // indirect
+	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/kustomize/api v0.19.0 // indirect
 	sigs.k8s.io/kustomize/kustomize/v5 v5.6.0 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.19.0 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect
+	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -76,9 +76,8 @@ github.com/aws/smithy-go v1.22.2/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxY
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
+github.com/caarlos0/env/v11 v11.3.1 h1:cArPWC15hWmEt+gWk7YBi7lEXTXCvpaSdCiZE2X5mCA=
 github.com/caarlos0/env/v11 v11.3.1/go.mod h1:qupehSf/Y0TUTsxKywqRt/vJjN5nz6vauiYEUUr8P4U=
-github.com/caarlos0/env/v6 v6.10.1 h1:t1mPSxNpei6M5yAeu1qtRdPAK29Nbcf/n3G7x+b3/II=
-github.com/caarlos0/env/v6 v6.10.1/go.mod h1:hvp/ryKXKipEkcuYjs9mI4bBCg+UI0Yhgm5Zu0ddvwc=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -457,8 +456,6 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.38.0 h1:jt+WWG8IZlBnVbomuhg2Mdq0+BBQaHbtqHEFEigjUV8=
 golang.org/x/crypto v0.38.0/go.mod h1:MvrbAqul58NNYPKnOra203SB9vpuZW0e+RRZV+Ggqjw=
-golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0 h1:R84qjqJb5nVJMxqWYb3np9L5ZsaDtB+a39EqjV0JSUM=
-golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0/go.mod h1:S9Xr4PYopiDyqSyp5NjCrhFrqg6A5zA2E/iPHPhqnS8=
 golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6 h1:y5zboxd6LQAqYIhHnB48p0ByQ/GnQx2BE33L8BOHQkI=
 golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6/go.mod h1:U6Lno4MTRCDY+Ba7aCcauB9T60gsv5s4ralQzP72ZoQ=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
@@ -511,8 +508,8 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.32.0 h1:Q7N1vhpkQv7ybVzLFtTjvQya2ewbwNDZzUgfXGqtMWU=
-golang.org/x/tools v0.32.0/go.mod h1:ZxrU41P/wAbZD8EDa6dDCa6XfpkhJ7HFMjHJXfBDu8s=
+golang.org/x/tools v0.33.0 h1:4qz2S3zmRxbGIhDIAgjxvFutSvH5EfnsYrRBj0UI0bc=
+golang.org/x/tools v0.33.0/go.mod h1:CIJMaWEY88juyUfo7UbgPqbC8rU2OqfAV1h2Qp0oMYI=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/args/args.go
+++ b/pkg/args/args.go
@@ -45,8 +45,10 @@ type Globals struct {
 
 type VersionFlag string
 
-const done = 1000
-const unset = -1000
+const (
+	done  = 1000
+	unset = -1000
+)
 
 var ErrDone = errors.New("version")
 

--- a/pkg/args/args_test.go
+++ b/pkg/args/args_test.go
@@ -40,7 +40,7 @@ func Test_Parse(t *testing.T) {
 	log.SetHandler(logMock)
 	log.SetLevel(log.DebugLevel)
 
-	var arguments = &struct {
+	arguments := &struct {
 		Globals
 		Name string
 	}{}
@@ -54,7 +54,7 @@ func Test_Help(t *testing.T) {
 	log.SetHandler(logMock)
 	log.SetLevel(log.DebugLevel)
 
-	var arguments = &struct {
+	arguments := &struct {
 		Globals
 		Name string
 	}{}
@@ -82,7 +82,7 @@ func Test_Version(t *testing.T) {
 	log.SetHandler(logMock)
 	log.SetLevel(log.DebugLevel)
 
-	var arguments = &struct {
+	arguments := &struct {
 		Globals
 		Name string
 	}{}
@@ -109,7 +109,7 @@ targets:
 	log.SetHandler(logMock)
 	log.SetLevel(log.DebugLevel)
 
-	var arguments = &struct {
+	arguments := &struct {
 		Globals
 		Name string
 	}{}
@@ -121,8 +121,10 @@ targets:
 		Date:        "date",
 	}, arguments)
 	require.Equal(t, err, ErrDone)
-	logMock.Check(t, []string{"debug: Parsing config from env: BUILDTOOLS_CONTENT\n",
-		"info: Current config\nci: none\nvcs: Git\nregistry: {}" + yaml})
+	logMock.Check(t, []string{
+		"debug: Parsing config from env: BUILDTOOLS_CONTENT\n",
+		"info: Current config\nci: none\nvcs: Git\nregistry: {}" + yaml,
+	})
 }
 
 func Test_Config_Error(t *testing.T) {
@@ -133,7 +135,7 @@ func Test_Config_Error(t *testing.T) {
 	log.SetHandler(logMock)
 	log.SetLevel(log.DebugLevel)
 
-	var arguments = &struct {
+	arguments := &struct {
 		Globals
 		Name string
 	}{}
@@ -157,7 +159,7 @@ func Test_Verbose_Enabled(t *testing.T) {
 	log.SetHandler(logMock)
 	log.SetLevel(log.InfoLevel)
 
-	var arguments = &struct {
+	arguments := &struct {
 		Globals
 		Name string
 	}{}
@@ -177,7 +179,7 @@ func Test_Verbose(t *testing.T) {
 	log.SetHandler(logMock)
 	log.SetLevel(log.InfoLevel)
 
-	var arguments = &struct {
+	arguments := &struct {
 		Globals
 		Name string
 	}{}

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -339,7 +339,7 @@ func getBuildSharedKey(dir string) string {
 
 func tryNodeIdentifier() string {
 	out := filepath.Join(os.TempDir(), ".buildtools") // return config dir as default on permission error
-	if err := os.MkdirAll(out, 0700); err == nil {
+	if err := os.MkdirAll(out, 0o700); err == nil {
 		sessionFile := filepath.Join(out, ".buildNodeID")
 		if _, err := os.Lstat(sessionFile); err != nil {
 			if os.IsNotExist(err) { // create a new file with stored randomness
@@ -347,7 +347,7 @@ func tryNodeIdentifier() string {
 				if _, err := rand.Read(b); err != nil {
 					return out
 				}
-				if err := os.WriteFile(sessionFile, []byte(hex.EncodeToString(b)), 0600); err != nil {
+				if err := os.WriteFile(sessionFile, []byte(hex.EncodeToString(b)), 0o600); err != nil {
 					return out
 				}
 			}

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -73,7 +73,7 @@ func teardown(buildToolsTempDir, osTempDir string) {
 func TestBuild_BrokenConfig(t *testing.T) {
 	yaml := `ci: [] `
 	file := filepath.Join(name, ".buildtools.yaml")
-	_ = os.WriteFile(file, []byte(yaml), 0777)
+	_ = os.WriteFile(file, []byte(yaml), 0o777)
 	defer func() { _ = os.Remove(file) }()
 
 	logMock := mocks.New()
@@ -114,13 +114,15 @@ func TestBuild_NoRegistry(t *testing.T) {
 
 	err := DoBuild(name, Args{Dockerfile: "Dockerfile"})
 	assert.NoError(t, err)
-	logMock.Check(t, []string{"debug: Using CI <green>Gitlab</green>\n",
+	logMock.Check(t, []string{
+		"debug: Using CI <green>Gitlab</green>\n",
 		"debug: Using registry <green>No docker registry</green>\n",
 		"debug: Authenticating against registry <green>No docker registry</green>\n",
 		"debug: Authentication <yellow>not supported</yellow> for registry <green>No docker registry</green>\n",
 		"debug: Using build variables commit <green>abc123</green> on branch <green>feature1</green>\n",
 		"debug: performing docker build with options (auths removed):\ntags:\n    - noregistry/reponame:abc123\n    - noregistry/reponame:feature1\nsuppressoutput: false\nremotecontext: client-session\nnocache: false\nremove: true\nforceremove: false\npullparent: true\nisolation: \"\"\ncpusetcpus: \"\"\ncpusetmems: \"\"\ncpushares: 0\ncpuquota: 0\ncpuperiod: 0\nmemory: 0\nmemoryswap: -1\ncgroupparent: \"\"\nnetworkmode: \"\"\nshmsize: 268435456\ndockerfile: Dockerfile\nulimits: []\nbuildargs:\n    BUILDKIT_INLINE_CACHE: \"1\"\n    CI_BRANCH: feature1\n    CI_COMMIT: abc123\nauthconfigs: {}\ncontext: null\nlabels: {}\nsquash: false\ncachefrom:\n    - noregistry/reponame:feature1\n    - noregistry/reponame:latest\nsecurityopt: []\nextrahosts: []\ntarget: \"\"\nsessionid: \"\"\nplatform: \"\"\nversion: \"2\"\nbuildid: \"\"\noutputs: []\n\n",
-		"info: Build successful"})
+		"info: Build successful",
+	})
 }
 
 func TestBuild_LoginError(t *testing.T) {
@@ -150,7 +152,8 @@ func TestBuild_LoginError(t *testing.T) {
 		"debug: Using CI <green>Gitlab</green>\n",
 		"debug: Using registry <green>Dockerhub</green>\n",
 		"debug: Authenticating against registry <green>Dockerhub</green>\n",
-		"error: Unable to login\n"})
+		"error: Unable to login\n",
+	})
 }
 
 func TestBuild_NoCI(t *testing.T) {
@@ -408,7 +411,8 @@ func TestBuild_WithStrangeBuildArg(t *testing.T) {
 		"debug: ignoring build-arg buildargs2\n",
 		"debug: ignoring build-arg buildargs3\n",
 		"debug: performing docker build with options (auths removed):\ntags:\n    - repo/reponame:sha\n    - repo/reponame:master\n    - repo/reponame:latest\nsuppressoutput: false\nremotecontext: client-session\nnocache: false\nremove: true\nforceremove: false\npullparent: true\nisolation: \"\"\ncpusetcpus: \"\"\ncpusetmems: \"\"\ncpushares: 0\ncpuquota: 0\ncpuperiod: 0\nmemory: 0\nmemoryswap: -1\ncgroupparent: \"\"\nnetworkmode: \"\"\nshmsize: 268435456\ndockerfile: Dockerfile\nulimits: []\nbuildargs:\n    BUILDKIT_INLINE_CACHE: \"1\"\n    CI_BRANCH: master\n    CI_COMMIT: sha\n    buildargs1: 1=1\n    buildargs4: env-value\nauthconfigs: {}\ncontext: null\nlabels: {}\nsquash: false\ncachefrom:\n    - repo/reponame:master\n    - repo/reponame:latest\nsecurityopt: []\nextrahosts: []\ntarget: \"\"\nsessionid: \"\"\nplatform: \"\"\nversion: \"2\"\nbuildid: \"\"\noutputs: []\n\n",
-		"info: Build successful"})
+		"info: Build successful",
+	})
 }
 
 func TestBuild_WithPlatform(t *testing.T) {
@@ -440,7 +444,8 @@ func TestBuild_WithPlatform(t *testing.T) {
 		"debug: Logged in\n",
 		"debug: Using build variables commit <green>sha</green> on branch <green>master</green>\n",
 		"debug: performing docker build with options (auths removed):\ntags:\n    - repo/reponame:sha\n    - repo/reponame:master\n    - repo/reponame:latest\nsuppressoutput: false\nremotecontext: client-session\nnocache: false\nremove: true\nforceremove: false\npullparent: true\nisolation: \"\"\ncpusetcpus: \"\"\ncpusetmems: \"\"\ncpushares: 0\ncpuquota: 0\ncpuperiod: 0\nmemory: 0\nmemoryswap: -1\ncgroupparent: \"\"\nnetworkmode: \"\"\nshmsize: 268435456\ndockerfile: Dockerfile\nulimits: []\nbuildargs:\n    BUILDKIT_INLINE_CACHE: \"1\"\n    CI_BRANCH: master\n    CI_COMMIT: sha\nauthconfigs: {}\ncontext: null\nlabels: {}\nsquash: false\ncachefrom:\n    - repo/reponame:master\n    - repo/reponame:latest\nsecurityopt: []\nextrahosts: []\ntarget: \"\"\nsessionid: \"\"\nplatform: linux/amd64\nversion: \"2\"\nbuildid: \"\"\noutputs: []\n\n",
-		"info: Build successful"})
+		"info: Build successful",
+	})
 }
 
 func TestBuild_WithSkipLogin(t *testing.T) {
@@ -469,7 +474,8 @@ func TestBuild_WithSkipLogin(t *testing.T) {
 		"debug: Login <yellow>disabled</yellow>\n",
 		"debug: Using build variables commit <green>sha</green> on branch <green>master</green>\n",
 		"debug: performing docker build with options (auths removed):\ntags:\n    - repo/reponame:sha\n    - repo/reponame:master\n    - repo/reponame:latest\nsuppressoutput: false\nremotecontext: client-session\nnocache: false\nremove: true\nforceremove: false\npullparent: true\nisolation: \"\"\ncpusetcpus: \"\"\ncpusetmems: \"\"\ncpushares: 0\ncpuquota: 0\ncpuperiod: 0\nmemory: 0\nmemoryswap: -1\ncgroupparent: \"\"\nnetworkmode: \"\"\nshmsize: 268435456\ndockerfile: Dockerfile\nulimits: []\nbuildargs:\n    BUILDKIT_INLINE_CACHE: \"1\"\n    CI_BRANCH: master\n    CI_COMMIT: sha\nauthconfigs: {}\ncontext: null\nlabels: {}\nsquash: false\ncachefrom:\n    - repo/reponame:master\n    - repo/reponame:latest\nsecurityopt: []\nextrahosts: []\ntarget: \"\"\nsessionid: \"\"\nplatform: \"\"\nversion: \"2\"\nbuildid: \"\"\noutputs: []\n\n",
-		"info: Build successful"})
+		"info: Build successful",
+	})
 }
 
 func TestBuild_FeatureBranch(t *testing.T) {
@@ -509,13 +515,15 @@ func TestBuild_FeatureBranch(t *testing.T) {
 	assert.Equal(t, true, client.BuildOptions[0].Remove)
 	assert.Equal(t, int64(256*1024*1024), client.BuildOptions[0].ShmSize)
 	assert.Equal(t, []string{"repo/reponame:abc123", "repo/reponame:feature1"}, client.BuildOptions[0].Tags)
-	logMock.Check(t, []string{"debug: Using CI <green>Gitlab</green>\n",
+	logMock.Check(t, []string{
+		"debug: Using CI <green>Gitlab</green>\n",
 		"debug: Using registry <green>Dockerhub</green>\n",
 		"debug: Authenticating against registry <green>Dockerhub</green>\n",
 		"debug: Logged in\n",
 		"debug: Using build variables commit <green>abc123</green> on branch <green>feature1</green>\n",
 		"debug: performing docker build with options (auths removed):\ntags:\n    - repo/reponame:abc123\n    - repo/reponame:feature1\nsuppressoutput: false\nremotecontext: client-session\nnocache: false\nremove: true\nforceremove: false\npullparent: true\nisolation: \"\"\ncpusetcpus: \"\"\ncpusetmems: \"\"\ncpushares: 0\ncpuquota: 0\ncpuperiod: 0\nmemory: 0\nmemoryswap: -1\ncgroupparent: \"\"\nnetworkmode: \"\"\nshmsize: 268435456\ndockerfile: Dockerfile\nulimits: []\nbuildargs:\n    BUILDKIT_INLINE_CACHE: \"1\"\n    CI_BRANCH: feature1\n    CI_COMMIT: abc123\nauthconfigs: {}\ncontext: null\nlabels: {}\nsquash: false\ncachefrom:\n    - repo/reponame:feature1\n    - repo/reponame:latest\nsecurityopt: []\nextrahosts: []\ntarget: \"\"\nsessionid: \"\"\nplatform: \"\"\nversion: \"2\"\nbuildid: \"\"\noutputs: []\n\n",
-		"info: Build successful"})
+		"info: Build successful",
+	})
 }
 
 func TestBuild_MasterBranch(t *testing.T) {
@@ -547,13 +555,15 @@ func TestBuild_MasterBranch(t *testing.T) {
 	assert.Equal(t, true, client.BuildOptions[0].Remove)
 	assert.Equal(t, int64(256*1024*1024), client.BuildOptions[0].ShmSize)
 	assert.Equal(t, []string{"repo/reponame:abc123", "repo/reponame:master", "repo/reponame:latest"}, client.BuildOptions[0].Tags)
-	logMock.Check(t, []string{"debug: Using CI <green>Gitlab</green>\n",
+	logMock.Check(t, []string{
+		"debug: Using CI <green>Gitlab</green>\n",
 		"debug: Using registry <green>Dockerhub</green>\n",
 		"debug: Authenticating against registry <green>Dockerhub</green>\n",
 		"debug: Logged in\n",
 		"debug: Using build variables commit <green>abc123</green> on branch <green>master</green>\n",
 		"debug: performing docker build with options (auths removed):\ntags:\n    - repo/reponame:abc123\n    - repo/reponame:master\n    - repo/reponame:latest\nsuppressoutput: false\nremotecontext: client-session\nnocache: false\nremove: true\nforceremove: false\npullparent: true\nisolation: \"\"\ncpusetcpus: \"\"\ncpusetmems: \"\"\ncpushares: 0\ncpuquota: 0\ncpuperiod: 0\nmemory: 0\nmemoryswap: -1\ncgroupparent: \"\"\nnetworkmode: \"\"\nshmsize: 268435456\ndockerfile: Dockerfile\nulimits: []\nbuildargs:\n    BUILDKIT_INLINE_CACHE: \"1\"\n    CI_BRANCH: master\n    CI_COMMIT: abc123\nauthconfigs: {}\ncontext: null\nlabels: {}\nsquash: false\ncachefrom:\n    - repo/reponame:master\n    - repo/reponame:latest\nsecurityopt: []\nextrahosts: []\ntarget: \"\"\nsessionid: \"\"\nplatform: \"\"\nversion: \"2\"\nbuildid: \"\"\noutputs: []\n\n",
-		"info: Build successful"})
+		"info: Build successful",
+	})
 }
 
 func TestBuild_MainBranch(t *testing.T) {
@@ -585,13 +595,15 @@ func TestBuild_MainBranch(t *testing.T) {
 	assert.Equal(t, true, client.BuildOptions[0].Remove)
 	assert.Equal(t, int64(256*1024*1024), client.BuildOptions[0].ShmSize)
 	assert.Equal(t, []string{"repo/reponame:abc123", "repo/reponame:main", "repo/reponame:latest"}, client.BuildOptions[0].Tags)
-	logMock.Check(t, []string{"debug: Using CI <green>Gitlab</green>\n",
+	logMock.Check(t, []string{
+		"debug: Using CI <green>Gitlab</green>\n",
 		"debug: Using registry <green>Dockerhub</green>\n",
 		"debug: Authenticating against registry <green>Dockerhub</green>\n",
 		"debug: Logged in\n",
 		"debug: Using build variables commit <green>abc123</green> on branch <green>main</green>\n",
 		"debug: performing docker build with options (auths removed):\ntags:\n    - repo/reponame:abc123\n    - repo/reponame:main\n    - repo/reponame:latest\nsuppressoutput: false\nremotecontext: client-session\nnocache: false\nremove: true\nforceremove: false\npullparent: true\nisolation: \"\"\ncpusetcpus: \"\"\ncpusetmems: \"\"\ncpushares: 0\ncpuquota: 0\ncpuperiod: 0\nmemory: 0\nmemoryswap: -1\ncgroupparent: \"\"\nnetworkmode: \"\"\nshmsize: 268435456\ndockerfile: Dockerfile\nulimits: []\nbuildargs:\n    BUILDKIT_INLINE_CACHE: \"1\"\n    CI_BRANCH: main\n    CI_COMMIT: abc123\nauthconfigs: {}\ncontext: null\nlabels: {}\nsquash: false\ncachefrom:\n    - repo/reponame:main\n    - repo/reponame:latest\nsecurityopt: []\nextrahosts: []\ntarget: \"\"\nsessionid: \"\"\nplatform: \"\"\nversion: \"2\"\nbuildid: \"\"\noutputs: []\n\n",
-		"info: Build successful"})
+		"info: Build successful",
+	})
 }
 
 func TestBuild_WithImageName(t *testing.T) {
@@ -624,7 +636,8 @@ func TestBuild_WithImageName(t *testing.T) {
 	assert.Equal(t, true, client.BuildOptions[0].Remove)
 	assert.Equal(t, int64(256*1024*1024), client.BuildOptions[0].ShmSize)
 	assert.Equal(t, []string{"repo/other:abc123", "repo/other:main", "repo/other:latest"}, client.BuildOptions[0].Tags)
-	logMock.Check(t, []string{"debug: Using CI <green>Gitlab</green>\n",
+	logMock.Check(t, []string{
+		"debug: Using CI <green>Gitlab</green>\n",
 		"debug: Using registry <green>Dockerhub</green>\n",
 		"debug: Authenticating against registry <green>Dockerhub</green>\n",
 		"debug: Logged in\n",
@@ -633,7 +646,8 @@ func TestBuild_WithImageName(t *testing.T) {
 		"info: Using other as BuildName\n",
 		"info: Using other as BuildName\n",
 		"debug: performing docker build with options (auths removed):\ntags:\n    - repo/other:abc123\n    - repo/other:main\n    - repo/other:latest\nsuppressoutput: false\nremotecontext: client-session\nnocache: false\nremove: true\nforceremove: false\npullparent: true\nisolation: \"\"\ncpusetcpus: \"\"\ncpusetmems: \"\"\ncpushares: 0\ncpuquota: 0\ncpuperiod: 0\nmemory: 0\nmemoryswap: -1\ncgroupparent: \"\"\nnetworkmode: \"\"\nshmsize: 268435456\ndockerfile: Dockerfile\nulimits: []\nbuildargs:\n    BUILDKIT_INLINE_CACHE: \"1\"\n    CI_BRANCH: main\n    CI_COMMIT: abc123\nauthconfigs: {}\ncontext: null\nlabels: {}\nsquash: false\ncachefrom:\n    - repo/other:main\n    - repo/other:latest\nsecurityopt: []\nextrahosts: []\ntarget: \"\"\nsessionid: \"\"\nplatform: \"\"\nversion: \"2\"\nbuildid: \"\"\noutputs: []\n\n",
-		"info: Build successful"})
+		"info: Build successful",
+	})
 }
 
 func TestBuild_BadDockerHost(t *testing.T) {
@@ -656,7 +670,7 @@ func TestBuild_Unreadable_Dockerfile(t *testing.T) {
 
 	defer func() { _ = os.RemoveAll(name) }()
 	dockerfile := filepath.Join(name, "Dockerfile")
-	_ = os.MkdirAll(dockerfile, 0777)
+	_ = os.MkdirAll(dockerfile, 0o777)
 
 	logMock := mocks.New()
 	log.SetHandler(logMock)
@@ -728,7 +742,7 @@ func TestBuild_Dockerfile_FromStdin(t *testing.T) {
 	client := &docker.MockDocker{}
 
 	defer func() { _ = os.RemoveAll(name) }()
-	err := os.MkdirAll(name, 0777)
+	err := os.MkdirAll(name, 0o777)
 	assert.NoError(t, err)
 
 	err = build(client, name, Args{
@@ -798,7 +812,8 @@ COPY --from=test file2 .
 	assert.Equal(t, []string{"repo/reponame:build", "repo/reponame:master", "repo/reponame:latest"}, client.BuildOptions[0].CacheFrom)
 	assert.Equal(t, []string{"repo/reponame:test", "repo/reponame:build", "repo/reponame:master", "repo/reponame:latest"}, client.BuildOptions[1].CacheFrom)
 	assert.Equal(t, []string{"repo/reponame:test", "repo/reponame:build", "repo/reponame:master", "repo/reponame:latest"}, client.BuildOptions[2].CacheFrom)
-	logMock.Check(t, []string{"debug: Using CI <green>Gitlab</green>\n",
+	logMock.Check(t, []string{
+		"debug: Using CI <green>Gitlab</green>\n",
 		"debug: Using registry <green>Dockerhub</green>\n",
 		"debug: Authenticating against registry <green>Dockerhub</green>\n",
 		"debug: Logged in\n",
@@ -808,7 +823,8 @@ COPY --from=test file2 .
 		"debug: performing docker build with options (auths removed):\ntags:\n    - repo/reponame:test\nsuppressoutput: false\nremotecontext: client-session\nnocache: false\nremove: true\nforceremove: false\npullparent: true\nisolation: \"\"\ncpusetcpus: \"\"\ncpusetmems: \"\"\ncpushares: 0\ncpuquota: 0\ncpuperiod: 0\nmemory: 0\nmemoryswap: -1\ncgroupparent: \"\"\nnetworkmode: \"\"\nshmsize: 268435456\ndockerfile: Dockerfile\nulimits: []\nbuildargs:\n    BUILDKIT_INLINE_CACHE: \"1\"\n    CI_BRANCH: master\n    CI_COMMIT: abc123\nauthconfigs: {}\ncontext: null\nlabels: {}\nsquash: false\ncachefrom:\n    - repo/reponame:test\n    - repo/reponame:build\n    - repo/reponame:master\n    - repo/reponame:latest\nsecurityopt: []\nextrahosts: []\ntarget: test\nsessionid: \"\"\nplatform: \"\"\nversion: \"2\"\nbuildid: \"\"\noutputs: []\n\n",
 		"info: Build successful",
 		"debug: performing docker build with options (auths removed):\ntags:\n    - repo/reponame:abc123\n    - repo/reponame:master\n    - repo/reponame:latest\nsuppressoutput: false\nremotecontext: client-session\nnocache: false\nremove: true\nforceremove: false\npullparent: true\nisolation: \"\"\ncpusetcpus: \"\"\ncpusetmems: \"\"\ncpushares: 0\ncpuquota: 0\ncpuperiod: 0\nmemory: 0\nmemoryswap: -1\ncgroupparent: \"\"\nnetworkmode: \"\"\nshmsize: 268435456\ndockerfile: Dockerfile\nulimits: []\nbuildargs:\n    BUILDKIT_INLINE_CACHE: \"1\"\n    CI_BRANCH: master\n    CI_COMMIT: abc123\nauthconfigs: {}\ncontext: null\nlabels: {}\nsquash: false\ncachefrom:\n    - repo/reponame:test\n    - repo/reponame:build\n    - repo/reponame:master\n    - repo/reponame:latest\nsecurityopt: []\nextrahosts: []\ntarget: \"\"\nsessionid: \"\"\nplatform: \"\"\nversion: \"2\"\nbuildid: \"\"\noutputs: []\n\n",
-		"info: Build successful"})
+		"info: Build successful",
+	})
 }
 
 func TestBuild_BrokenStage(t *testing.T) {
@@ -909,7 +925,8 @@ COPY --from=test file2 .
 	assert.Equal(t, []string{"repo/reponame:test", "repo/reponame:build", "repo/reponame:master", "repo/reponame:latest"}, client.BuildOptions[1].CacheFrom)
 	assert.Equal(t, []string{"repo/reponame:export", "repo/reponame:test", "repo/reponame:build", "repo/reponame:master", "repo/reponame:latest"}, client.BuildOptions[2].CacheFrom)
 	assert.Equal(t, []string{"repo/reponame:export", "repo/reponame:test", "repo/reponame:build", "repo/reponame:master", "repo/reponame:latest"}, client.BuildOptions[3].CacheFrom)
-	logMock.Check(t, []string{"debug: Using CI <green>Gitlab</green>\n",
+	logMock.Check(t, []string{
+		"debug: Using CI <green>Gitlab</green>\n",
 		"debug: Using registry <green>Dockerhub</green>\n",
 		"debug: Authenticating against registry <green>Dockerhub</green>\n",
 		"debug: Logged in\n",
@@ -921,7 +938,8 @@ COPY --from=test file2 .
 		"debug: performing docker build with options (auths removed):\ntags:\n    - repo/reponame:export\nsuppressoutput: false\nremotecontext: client-session\nnocache: false\nremove: true\nforceremove: false\npullparent: true\nisolation: \"\"\ncpusetcpus: \"\"\ncpusetmems: \"\"\ncpushares: 0\ncpuquota: 0\ncpuperiod: 0\nmemory: 0\nmemoryswap: -1\ncgroupparent: \"\"\nnetworkmode: \"\"\nshmsize: 268435456\ndockerfile: Dockerfile\nulimits: []\nbuildargs:\n    BUILDKIT_INLINE_CACHE: \"1\"\n    CI_BRANCH: master\n    CI_COMMIT: abc123\nauthconfigs: {}\ncontext: null\nlabels: {}\nsquash: false\ncachefrom:\n    - repo/reponame:export\n    - repo/reponame:test\n    - repo/reponame:build\n    - repo/reponame:master\n    - repo/reponame:latest\nsecurityopt: []\nextrahosts: []\ntarget: export\nsessionid: \"\"\nplatform: \"\"\nversion: \"2\"\nbuildid: \"\"\noutputs:\n    - type: local\n      attrs: {}\n\n",
 		"info: Build successful",
 		"debug: performing docker build with options (auths removed):\ntags:\n    - repo/reponame:abc123\n    - repo/reponame:master\n    - repo/reponame:latest\nsuppressoutput: false\nremotecontext: client-session\nnocache: false\nremove: true\nforceremove: false\npullparent: true\nisolation: \"\"\ncpusetcpus: \"\"\ncpusetmems: \"\"\ncpushares: 0\ncpuquota: 0\ncpuperiod: 0\nmemory: 0\nmemoryswap: -1\ncgroupparent: \"\"\nnetworkmode: \"\"\nshmsize: 268435456\ndockerfile: Dockerfile\nulimits: []\nbuildargs:\n    BUILDKIT_INLINE_CACHE: \"1\"\n    CI_BRANCH: master\n    CI_COMMIT: abc123\nauthconfigs: {}\ncontext: null\nlabels: {}\nsquash: false\ncachefrom:\n    - repo/reponame:export\n    - repo/reponame:test\n    - repo/reponame:build\n    - repo/reponame:master\n    - repo/reponame:latest\nsecurityopt: []\nextrahosts: []\ntarget: \"\"\nsessionid: \"\"\nplatform: \"\"\nversion: \"2\"\nbuildid: \"\"\noutputs: []\n\n",
-		"info: Build successful"})
+		"info: Build successful",
+	})
 }
 
 func TestBuild_ExportAsLastStage(t *testing.T) {
@@ -975,7 +993,8 @@ COPY --from=test file2 .
 	assert.Equal(t, []string{"repo/reponame:test", "repo/reponame:build", "repo/reponame:master", "repo/reponame:latest"}, client.BuildOptions[1].CacheFrom)
 	assert.Equal(t, []string{"repo/reponame:export", "repo/reponame:test", "repo/reponame:build", "repo/reponame:master", "repo/reponame:latest"}, client.BuildOptions[2].CacheFrom)
 	assert.Equal(t, []string{"repo/reponame:export", "repo/reponame:test", "repo/reponame:build", "repo/reponame:master", "repo/reponame:latest"}, client.BuildOptions[3].CacheFrom)
-	logMock.Check(t, []string{"debug: Using CI <green>Gitlab</green>\n",
+	logMock.Check(t, []string{
+		"debug: Using CI <green>Gitlab</green>\n",
 		"debug: Using registry <green>Dockerhub</green>\n",
 		"debug: Authenticating against registry <green>Dockerhub</green>\n",
 		"debug: Logged in\n",
@@ -987,7 +1006,8 @@ COPY --from=test file2 .
 		"debug: performing docker build with options (auths removed):\ntags:\n    - repo/reponame:export\nsuppressoutput: false\nremotecontext: client-session\nnocache: false\nremove: true\nforceremove: false\npullparent: true\nisolation: \"\"\ncpusetcpus: \"\"\ncpusetmems: \"\"\ncpushares: 0\ncpuquota: 0\ncpuperiod: 0\nmemory: 0\nmemoryswap: -1\ncgroupparent: \"\"\nnetworkmode: \"\"\nshmsize: 268435456\ndockerfile: Dockerfile\nulimits: []\nbuildargs:\n    BUILDKIT_INLINE_CACHE: \"1\"\n    CI_BRANCH: master\n    CI_COMMIT: abc123\nauthconfigs: {}\ncontext: null\nlabels: {}\nsquash: false\ncachefrom:\n    - repo/reponame:export\n    - repo/reponame:test\n    - repo/reponame:build\n    - repo/reponame:master\n    - repo/reponame:latest\nsecurityopt: []\nextrahosts: []\ntarget: export\nsessionid: \"\"\nplatform: \"\"\nversion: \"2\"\nbuildid: \"\"\noutputs:\n    - type: local\n      attrs: {}\n\n",
 		"info: Build successful",
 		"debug: performing docker build with options (auths removed):\ntags:\n    - repo/reponame:abc123\n    - repo/reponame:master\n    - repo/reponame:latest\nsuppressoutput: false\nremotecontext: client-session\nnocache: false\nremove: true\nforceremove: false\npullparent: true\nisolation: \"\"\ncpusetcpus: \"\"\ncpusetmems: \"\"\ncpushares: 0\ncpuquota: 0\ncpuperiod: 0\nmemory: 0\nmemoryswap: -1\ncgroupparent: \"\"\nnetworkmode: \"\"\nshmsize: 268435456\ndockerfile: Dockerfile\nulimits: []\nbuildargs:\n    BUILDKIT_INLINE_CACHE: \"1\"\n    CI_BRANCH: master\n    CI_COMMIT: abc123\nauthconfigs: {}\ncontext: null\nlabels: {}\nsquash: false\ncachefrom:\n    - repo/reponame:export\n    - repo/reponame:test\n    - repo/reponame:build\n    - repo/reponame:master\n    - repo/reponame:latest\nsecurityopt: []\nextrahosts: []\ntarget: \"\"\nsessionid: \"\"\nplatform: \"\"\nversion: \"2\"\nbuildid: \"\"\noutputs: []\n\n",
-		"info: Build successful"})
+		"info: Build successful",
+	})
 }
 
 type brokenReader struct{}
@@ -999,8 +1019,8 @@ func (b brokenReader) Read([]byte) (n int, err error) {
 var _ io.Reader = &brokenReader{}
 
 func write(dir, file, content string) error {
-	if err := os.MkdirAll(filepath.Dir(filepath.Join(dir, file)), 0777); err != nil {
+	if err := os.MkdirAll(filepath.Dir(filepath.Join(dir, file)), 0o777); err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(dir, file), []byte(fmt.Sprintln(strings.TrimSpace(content))), 0666)
+	return os.WriteFile(filepath.Join(dir, file), []byte(fmt.Sprintln(strings.TrimSpace(content))), 0o666)
 }

--- a/pkg/build/testing.go
+++ b/pkg/build/testing.go
@@ -28,8 +28,7 @@ import (
 	"github.com/moby/buildkit/session"
 )
 
-type MockSession struct {
-}
+type MockSession struct{}
 
 func (m *MockSession) Allow(a session.Attachable) {
 }

--- a/pkg/ci/github_test.go
+++ b/pkg/ci/github_test.go
@@ -78,6 +78,7 @@ func TestGithub_Branch_Tag(t *testing.T) {
 
 	assert.Equal(t, "feature1", ci.Branch())
 }
+
 func TestGithub_Branch(t *testing.T) {
 	ci := &Github{CIBranchName: "feature1"}
 

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -101,8 +101,7 @@ func (c *checkLocker) Unlock() {
 	c.unlockCalled = c.unlockCalled + 1
 }
 
-type invalidLog struct {
-}
+type invalidLog struct{}
 
 func (i invalidLog) WithFields(fielder log.Fielder) *log.Entry {
 	panic("implement me")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,7 +34,7 @@ import (
 
 	"dario.cat/mergo"
 	"github.com/apex/log"
-	"github.com/caarlos0/env/v6"
+	"github.com/caarlos0/env/v11"
 	"gopkg.in/yaml.v3"
 
 	"github.com/buildtool/build-tools/pkg/ci"

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -96,7 +96,7 @@ func TestLoad_BrokenYAML(t *testing.T) {
 	defer func() { _ = os.RemoveAll(name) }()
 	yaml := `ci: []
 `
-	_ = os.WriteFile(filepath.Join(name, ".buildtools.yaml"), []byte(yaml), 0777)
+	_ = os.WriteFile(filepath.Join(name, ".buildtools.yaml"), []byte(yaml), 0o777)
 
 	logMock := mocks.New()
 	log.SetHandler(logMock)
@@ -114,7 +114,7 @@ func TestLoad_UnreadableFile(t *testing.T) {
 	name, _ := os.MkdirTemp(os.TempDir(), "build-tools")
 	defer func() { _ = os.RemoveAll(name) }()
 	filename := filepath.Join(name, ".buildtools.yaml")
-	_ = os.Mkdir(filename, 0777)
+	_ = os.Mkdir(filename, 0o777)
 
 	logMock := mocks.New()
 	log.SetHandler(logMock)
@@ -143,7 +143,7 @@ targets:
     context: docker-desktop
     namespace: dev
 `
-	_ = os.WriteFile(filepath.Join(name, ".buildtools.yaml"), []byte(yaml), 0777)
+	_ = os.WriteFile(filepath.Join(name, ".buildtools.yaml"), []byte(yaml), 0o777)
 
 	logMock := mocks.New()
 	log.SetHandler(logMock)
@@ -204,8 +204,10 @@ targets:
 	log.SetLevel(log.DebugLevel)
 	cfg, err := Load(name)
 	assert.NoError(t, err)
-	logMock.Check(t, []string{"debug: Parsing config from env: BUILDTOOLS_CONTENT\n",
-		"debug: Failed to decode BASE64, falling back to plaintext\n"})
+	logMock.Check(t, []string{
+		"debug: Parsing config from env: BUILDTOOLS_CONTENT\n",
+		"debug: Failed to decode BASE64, falling back to plaintext\n",
+	})
 	assert.Equal(t, len(cfg.Targets), 1)
 	assert.Equal(t, cfg.Targets["local"].Context, "docker-desktop")
 }
@@ -271,15 +273,15 @@ targets:
   local:
     context: def
 `
-	_ = os.WriteFile(filepath.Join(name, ".buildtools.yaml"), []byte(yaml), 0777)
+	_ = os.WriteFile(filepath.Join(name, ".buildtools.yaml"), []byte(yaml), 0o777)
 	subdir := "sub"
-	_ = os.Mkdir(filepath.Join(name, subdir), 0777)
+	_ = os.Mkdir(filepath.Join(name, subdir), 0o777)
 	yaml2 := `
 targets:
   test:
     context: ghi
 `
-	_ = os.WriteFile(filepath.Join(name, subdir, ".buildtools.yaml"), []byte(yaml2), 0777)
+	_ = os.WriteFile(filepath.Join(name, subdir, ".buildtools.yaml"), []byte(yaml2), 0o777)
 
 	logMock := mocks.New()
 	log.SetHandler(logMock)
@@ -295,8 +297,10 @@ targets:
 	assert.Equal(t, 2, len(cfg.Targets))
 	assert.Equal(t, "ghi", cfg.Targets["test"].Context)
 	assert.Equal(t, "def", cfg.Targets["local"].Context)
-	logMock.Check(t, []string{fmt.Sprintf("debug: Parsing config from file: <green>'%s/sub/.buildtools.yaml'</green>\n", name),
-		fmt.Sprintf("debug: Merging with config from file: <green>'%s/.buildtools.yaml'</green>\n", name)})
+	logMock.Check(t, []string{
+		fmt.Sprintf("debug: Parsing config from file: <green>'%s/sub/.buildtools.yaml'</green>\n", name),
+		fmt.Sprintf("debug: Merging with config from file: <green>'%s/.buildtools.yaml'</green>\n", name),
+	})
 }
 
 func TestLoad_YAML_Multiple_Registry(t *testing.T) {
@@ -316,7 +320,7 @@ targets:
     context: docker-desktop
     namespace: dev
 `
-	_ = os.WriteFile(filepath.Join(name, ".buildtools.yaml"), []byte(yaml), 0777)
+	_ = os.WriteFile(filepath.Join(name, ".buildtools.yaml"), []byte(yaml), 0o777)
 
 	logMock := mocks.New()
 	log.SetHandler(logMock)

--- a/pkg/config/vcs_test.go
+++ b/pkg/config/vcs_test.go
@@ -75,7 +75,7 @@ func TestGit_Identify_Subdirectory(t *testing.T) {
 	hash, _ := InitRepoWithCommit(dir)
 
 	subdir := filepath.Join(dir, "subdir")
-	_ = os.Mkdir(subdir, 0777)
+	_ = os.Mkdir(subdir, 0o777)
 
 	logMock := mocks.New()
 	log.SetHandler(logMock)
@@ -92,7 +92,7 @@ func TestGit_MissingRepo(t *testing.T) {
 	dir, _ := os.MkdirTemp(os.TempDir(), "build-tools")
 	defer func() { _ = os.RemoveAll(dir) }()
 
-	_ = os.Mkdir(filepath.Join(dir, ".git"), 0777)
+	_ = os.Mkdir(filepath.Join(dir, ".git"), 0o777)
 
 	logMock := mocks.New()
 	log.SetHandler(logMock)

--- a/pkg/deploy/deploy_test.go
+++ b/pkg/deploy/deploy_test.go
@@ -66,7 +66,7 @@ func TestDeploy_NoFiles(t *testing.T) {
 
 	name, _ := os.MkdirTemp(os.TempDir(), "build-tools")
 	defer func() { _ = os.RemoveAll(name) }()
-	_ = os.Mkdir(filepath.Join(name, "k8s"), 0777)
+	_ = os.Mkdir(filepath.Join(name, "k8s"), 0o777)
 
 	logMock := mocks.New()
 	log.SetHandler(logMock)
@@ -92,7 +92,7 @@ func TestDeploy_NoEnvSpecificFiles(t *testing.T) {
 
 	name, _ := os.MkdirTemp(os.TempDir(), "build-tools")
 	defer func() { _ = os.RemoveAll(name) }()
-	_ = os.Mkdir(filepath.Join(name, "k8s"), 0777)
+	_ = os.Mkdir(filepath.Join(name, "k8s"), 0o777)
 	yaml := `
 apiVersion: v1
 kind: Namespace
@@ -100,7 +100,7 @@ metadata:
   name: dummy
 `
 	deployFile := filepath.Join(name, "k8s", "deploy.yaml")
-	_ = os.WriteFile(deployFile, []byte(yaml), 0777)
+	_ = os.WriteFile(deployFile, []byte(yaml), 0o777)
 
 	logMock := mocks.New()
 	log.SetHandler(logMock)
@@ -131,7 +131,7 @@ func TestDeploy_UnreadableFile(t *testing.T) {
 
 	name, _ := os.MkdirTemp(os.TempDir(), "build-tools")
 	defer func() { _ = os.RemoveAll(name) }()
-	_ = os.MkdirAll(filepath.Join(name, "k8s", "deploy.yaml"), 0777)
+	_ = os.MkdirAll(filepath.Join(name, "k8s", "deploy.yaml"), 0o777)
 
 	logMock := mocks.New()
 	log.SetHandler(logMock)
@@ -148,7 +148,8 @@ func TestDeploy_UnreadableFile(t *testing.T) {
 	assert.EqualError(t, err, fmt.Sprintf("read %s/k8s/deploy.yaml: is a directory", name))
 	logMock.Check(t, []string{
 		"debug: considering file '<yellow>deploy.yaml</yellow>' for target: <green></green>\n",
-		"debug: using file '<green>deploy.yaml</green>' for target: <green></green>\n"})
+		"debug: using file '<green>deploy.yaml</green>' for target: <green></green>\n",
+	})
 }
 
 func TestDeploy_FileBrokenSymlink(t *testing.T) {
@@ -158,9 +159,9 @@ func TestDeploy_FileBrokenSymlink(t *testing.T) {
 
 	name, _ := os.MkdirTemp(os.TempDir(), "build-tools")
 	defer func() { _ = os.RemoveAll(name) }()
-	_ = os.MkdirAll(filepath.Join(name, "k8s"), 0777)
+	_ = os.MkdirAll(filepath.Join(name, "k8s"), 0o777)
 	deployFile := filepath.Join(name, "k8s", "ns.yaml")
-	_ = os.WriteFile(deployFile, []byte("test"), 0777)
+	_ = os.WriteFile(deployFile, []byte("test"), 0o777)
 	_ = os.Symlink(deployFile, filepath.Join(name, "k8s", "deploy.yaml"))
 	_ = os.Remove(deployFile)
 
@@ -181,7 +182,6 @@ func TestDeploy_FileBrokenSymlink(t *testing.T) {
 		"debug: considering file '<yellow>deploy.yaml</yellow>' for target: <green></green>\n",
 		"debug: using file '<green>deploy.yaml</green>' for target: <green></green>\n",
 	})
-
 }
 
 func TestDeploy_EnvSpecificFilesWithSuffix(t *testing.T) {
@@ -191,7 +191,7 @@ func TestDeploy_EnvSpecificFilesWithSuffix(t *testing.T) {
 
 	name, _ := os.MkdirTemp(os.TempDir(), "build-tools")
 	defer func() { _ = os.RemoveAll(name) }()
-	_ = os.Mkdir(filepath.Join(name, "k8s"), 0777)
+	_ = os.Mkdir(filepath.Join(name, "k8s"), 0o777)
 	yaml := `
 apiVersion: v1
 kind: Namespace
@@ -199,7 +199,7 @@ metadata:
   name: dummy
 `
 	deployFile := filepath.Join(name, "k8s", "ns-dummy.yaml")
-	_ = os.WriteFile(deployFile, []byte(yaml), 0777)
+	_ = os.WriteFile(deployFile, []byte(yaml), 0o777)
 
 	logMock := mocks.New()
 	log.SetHandler(logMock)
@@ -230,11 +230,11 @@ func TestDeploy_EnvSpecificFiles(t *testing.T) {
 
 	name, _ := os.MkdirTemp(os.TempDir(), "build-tools")
 	defer func() { _ = os.RemoveAll(name) }()
-	_ = os.MkdirAll(filepath.Join(name, "k8s", "prod"), 0777)
+	_ = os.MkdirAll(filepath.Join(name, "k8s", "prod"), 0o777)
 	deployFile := filepath.Join(name, "k8s", "ns-dummy.yaml")
-	_ = os.WriteFile(deployFile, []byte("dummy yaml content"), 0777)
-	_ = os.WriteFile(filepath.Join(name, "k8s", "ns-prod.yaml"), []byte("prod content"), 0777)
-	_ = os.WriteFile(filepath.Join(name, "k8s", "other-dummy.sh"), []byte("dummy script content"), 0777)
+	_ = os.WriteFile(deployFile, []byte("dummy yaml content"), 0o777)
+	_ = os.WriteFile(filepath.Join(name, "k8s", "ns-prod.yaml"), []byte("prod content"), 0o777)
+	_ = os.WriteFile(filepath.Join(name, "k8s", "other-dummy.sh"), []byte("dummy script content"), 0o777)
 
 	logMock := mocks.New()
 	log.SetHandler(logMock)
@@ -268,11 +268,11 @@ func TestDeploy_IgnoreEmptyFiles(t *testing.T) {
 
 	name, _ := os.MkdirTemp(os.TempDir(), "build-tools")
 	defer func() { _ = os.RemoveAll(name) }()
-	_ = os.MkdirAll(filepath.Join(name, "k8s", "prod"), 0777)
+	_ = os.MkdirAll(filepath.Join(name, "k8s", "prod"), 0o777)
 	deployFile := filepath.Join(name, "k8s", "ns-dummy.yaml")
-	_ = os.WriteFile(deployFile, []byte("dummy yaml content"), 0777)
-	_ = os.WriteFile(filepath.Join(name, "k8s", "ns-prod.yaml"), []byte(""), 0777)
-	_ = os.WriteFile(filepath.Join(name, "k8s", "other-dummy.sh"), []byte("dummy script content"), 0777)
+	_ = os.WriteFile(deployFile, []byte("dummy yaml content"), 0o777)
+	_ = os.WriteFile(filepath.Join(name, "k8s", "ns-prod.yaml"), []byte(""), 0o777)
+	_ = os.WriteFile(filepath.Join(name, "k8s", "other-dummy.sh"), []byte("dummy script content"), 0o777)
 
 	logMock := mocks.New()
 	log.SetHandler(logMock)
@@ -305,10 +305,10 @@ func TestDeploy_ScriptExecution_NameSuffix(t *testing.T) {
 
 	name, _ := os.MkdirTemp(os.TempDir(), "build-tools")
 	defer func() { _ = os.RemoveAll(name) }()
-	_ = os.MkdirAll(filepath.Join(name, "k8s", "prod"), 0777)
+	_ = os.MkdirAll(filepath.Join(name, "k8s", "prod"), 0o777)
 	script := `#!/usr/bin/env bash
 echo "Prod-script with suffix"`
-	_ = os.WriteFile(filepath.Join(name, "k8s", "setup-prod.sh"), []byte(script), 0777)
+	_ = os.WriteFile(filepath.Join(name, "k8s", "setup-prod.sh"), []byte(script), 0o777)
 
 	logMock := mocks.New()
 	log.SetHandler(logMock)
@@ -337,13 +337,13 @@ func TestDeploy_ScriptExecution_No_Execute_Of_Common_If_Specific_Exists(t *testi
 
 	name, _ := os.MkdirTemp(os.TempDir(), "build-tools")
 	defer func() { _ = os.RemoveAll(name) }()
-	_ = os.MkdirAll(filepath.Join(name, "k8s", "prod"), 0777)
+	_ = os.MkdirAll(filepath.Join(name, "k8s", "prod"), 0o777)
 	script := `#!/usr/bin/env bash
 echo "Script without suffix should not execute"`
-	_ = os.WriteFile(filepath.Join(name, "k8s", "setup.sh"), []byte(script), 0777)
+	_ = os.WriteFile(filepath.Join(name, "k8s", "setup.sh"), []byte(script), 0o777)
 	script2 := `#!/usr/bin/env bash
 echo "Prod-script with suffix"`
-	_ = os.WriteFile(filepath.Join(name, "k8s", "setup-prod.sh"), []byte(script2), 0777)
+	_ = os.WriteFile(filepath.Join(name, "k8s", "setup-prod.sh"), []byte(script2), 0o777)
 
 	logMock := mocks.New()
 	log.SetHandler(logMock)
@@ -374,11 +374,11 @@ func TestDeploy_ScriptExecution_NotExecutable(t *testing.T) {
 
 	name, _ := os.MkdirTemp(os.TempDir(), "build-tools")
 	defer func() { _ = os.RemoveAll(name) }()
-	_ = os.MkdirAll(filepath.Join(name, "k8s", "prod"), 0777)
+	_ = os.MkdirAll(filepath.Join(name, "k8s", "prod"), 0o777)
 	script := `#!/usr/bin/env bash
 echo "Prod-script with suffix"`
 	scriptName := filepath.Join(name, "k8s", "setup-prod.sh")
-	_ = os.WriteFile(scriptName, []byte(script), 0666)
+	_ = os.WriteFile(scriptName, []byte(script), 0o666)
 
 	err := Deploy(name, "image", "registryUrl", "20190513-17:22:36", client, Args{
 		Globals:   args.Globals{},
@@ -398,7 +398,7 @@ func TestDeploy_ErrorFromApply(t *testing.T) {
 
 	name, _ := os.MkdirTemp(os.TempDir(), "build-tools")
 	defer func() { _ = os.RemoveAll(name) }()
-	_ = os.Mkdir(filepath.Join(name, "k8s"), 0777)
+	_ = os.Mkdir(filepath.Join(name, "k8s"), 0o777)
 	yaml := `
 apiVersion: v1
 kind: Namespace
@@ -406,7 +406,7 @@ metadata:
   name: dummy
 `
 	deployFile := filepath.Join(name, "k8s", "deploy.yaml")
-	_ = os.WriteFile(deployFile, []byte(yaml), 0777)
+	_ = os.WriteFile(deployFile, []byte(yaml), 0o777)
 
 	logMock := mocks.New()
 	log.SetHandler(logMock)
@@ -435,7 +435,7 @@ func TestDeploy_ReplacingCommitAndTimestampAndImage(t *testing.T) {
 
 	name, _ := os.MkdirTemp(os.TempDir(), "build-tools")
 	defer func() { _ = os.RemoveAll(name) }()
-	_ = os.Mkdir(filepath.Join(name, "k8s"), 0777)
+	_ = os.Mkdir(filepath.Join(name, "k8s"), 0o777)
 	yaml := `
 apiVersion: v1
 kind: Namespace
@@ -446,7 +446,7 @@ metadata:
   timestamp: ${TIMESTAMP}
 `
 	deployFile := filepath.Join(name, "k8s", "deploy.yaml")
-	_ = os.WriteFile(deployFile, []byte(yaml), 0777)
+	_ = os.WriteFile(deployFile, []byte(yaml), 0o777)
 
 	logMock := mocks.New()
 	log.SetHandler(logMock)
@@ -486,7 +486,7 @@ func TestDeploy_DeploymentExists(t *testing.T) {
 
 	name, _ := os.MkdirTemp(os.TempDir(), "build-tools")
 	defer func() { _ = os.RemoveAll(name) }()
-	_ = os.Mkdir(filepath.Join(name, "k8s"), 0777)
+	_ = os.Mkdir(filepath.Join(name, "k8s"), 0o777)
 	yaml := `
 apiVersion: v1
 kind: Namespace
@@ -494,7 +494,7 @@ metadata:
   name: dummy
 `
 	deployFile := filepath.Join(name, "k8s", "deploy.yaml")
-	_ = os.WriteFile(deployFile, []byte(yaml), 0777)
+	_ = os.WriteFile(deployFile, []byte(yaml), 0o777)
 
 	logMock := mocks.New()
 	log.SetHandler(logMock)
@@ -530,7 +530,7 @@ func TestDeploy_RolloutStatusFail(t *testing.T) {
 
 	name, _ := os.MkdirTemp(os.TempDir(), "build-tools")
 	defer func() { _ = os.RemoveAll(name) }()
-	_ = os.Mkdir(filepath.Join(name, "k8s"), 0777)
+	_ = os.Mkdir(filepath.Join(name, "k8s"), 0o777)
 	yaml := `
 apiVersion: v1
 kind: Namespace
@@ -538,7 +538,7 @@ metadata:
   name: dummy
 `
 	deployFile := filepath.Join(name, "k8s", "deploy.yaml")
-	_ = os.WriteFile(deployFile, []byte(yaml), 0777)
+	_ = os.WriteFile(deployFile, []byte(yaml), 0o777)
 
 	logMock := mocks.New()
 	log.SetHandler(logMock)
@@ -555,7 +555,8 @@ metadata:
 	assert.EqualError(t, err, "failed to rollout")
 	assert.Equal(t, 1, len(client.Inputs))
 	assert.Equal(t, yaml, client.Inputs[0])
-	logMock.Check(t, []string{"debug: considering file '<yellow>deploy.yaml</yellow>' for target: <green></green>\n",
+	logMock.Check(t, []string{
+		"debug: considering file '<yellow>deploy.yaml</yellow>' for target: <green></green>\n",
 		"debug: using file '<green>deploy.yaml</green>' for target: <green></green>\n",
 		"debug: trying to apply: \n---\n\napiVersion: v1\nkind: Namespace\nmetadata:\n  name: dummy\n\n---\n",
 		"error: Rollout failed. Fetching events.\n",
@@ -572,7 +573,7 @@ func TestDeploy_NoWait(t *testing.T) {
 
 	name, _ := os.MkdirTemp(os.TempDir(), "build-tools")
 	defer func() { _ = os.RemoveAll(name) }()
-	_ = os.Mkdir(filepath.Join(name, "k8s"), 0777)
+	_ = os.Mkdir(filepath.Join(name, "k8s"), 0o777)
 	yaml := `
 apiVersion: v1
 kind: Namespace
@@ -580,7 +581,7 @@ metadata:
   name: dummy
 `
 	deployFile := filepath.Join(name, "k8s", "deploy.yaml")
-	_ = os.WriteFile(deployFile, []byte(yaml), 0777)
+	_ = os.WriteFile(deployFile, []byte(yaml), 0o777)
 
 	logMock := mocks.New()
 	log.SetHandler(logMock)

--- a/pkg/docker/auth_test.go
+++ b/pkg/docker/auth_test.go
@@ -45,5 +45,4 @@ func Test_Credentials(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "user", creds.Username)
 	require.Equal(t, "password", creds.Secret)
-
 }

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -71,7 +71,7 @@ func SlugifyTag(tag string) string {
 }
 
 func ParseDockerignore(dir, dockerfile string) ([]string, error) {
-	var defaultIgnore = []string{"k8s"}
+	defaultIgnore := []string{"k8s"}
 	filePath := filepath.Join(dir, ".dockerignore")
 	if _, err := os.Stat(filePath); os.IsNotExist(err) {
 		return defaultIgnore, nil
@@ -80,7 +80,7 @@ func ParseDockerignore(dir, dockerfile string) ([]string, error) {
 	if file, err := os.ReadFile(filePath); err != nil {
 		return defaultIgnore, err
 	} else {
-		var result = defaultIgnore
+		result := defaultIgnore
 		scanner := bufio.NewScanner(bytes.NewReader(file))
 		for scanner.Scan() {
 			text := scanner.Text()

--- a/pkg/docker/docker_test.go
+++ b/pkg/docker/docker_test.go
@@ -46,7 +46,7 @@ func TestParseDockerignore_EmptyFile(t *testing.T) {
 	defer func() { _ = os.RemoveAll(name) }()
 
 	content := ``
-	_ = os.WriteFile(filepath.Join(name, ".dockerignore"), []byte(content), 0777)
+	_ = os.WriteFile(filepath.Join(name, ".dockerignore"), []byte(content), 0o777)
 
 	defaultIgnores := []string{"k8s"}
 	result, err := ParseDockerignore(name, "Dockerfile")
@@ -58,7 +58,7 @@ func TestParseDockerignore_UnreadableFile(t *testing.T) {
 	name, _ := os.MkdirTemp(os.TempDir(), "build-tools")
 	defer func() { _ = os.RemoveAll(name) }()
 	filename := filepath.Join(name, ".dockerignore")
-	_ = os.Mkdir(filename, 0777)
+	_ = os.Mkdir(filename, 0o777)
 
 	_, err := ParseDockerignore(name, "Dockerfile")
 	assert.EqualError(t, err, fmt.Sprintf("read %s: is a directory", filename))
@@ -71,7 +71,7 @@ func TestParseDockerignore(t *testing.T) {
 	content := `
 node_modules
 *.swp`
-	_ = os.WriteFile(filepath.Join(name, ".dockerignore"), []byte(content), 0777)
+	_ = os.WriteFile(filepath.Join(name, ".dockerignore"), []byte(content), 0o777)
 
 	result, err := ParseDockerignore(name, "Dockerfile")
 	assert.NoError(t, err)
@@ -86,7 +86,7 @@ func TestParseDockerignore_Dockerfile_Ignored(t *testing.T) {
 node_modules
 Dockerfile
 *.swp`
-	_ = os.WriteFile(filepath.Join(name, ".dockerignore"), []byte(content), 0777)
+	_ = os.WriteFile(filepath.Join(name, ".dockerignore"), []byte(content), 0o777)
 
 	result, err := ParseDockerignore(name, "Dockerfile")
 	assert.NoError(t, err)

--- a/pkg/kubecmd/kubecmd_test.go
+++ b/pkg/kubecmd/kubecmd_test.go
@@ -49,7 +49,7 @@ func TestKubecmd_MissingArgumentsPrintUsageToOutWriter(t *testing.T) {
 	log.SetLevel(log.DebugLevel)
 	cmd := Kubecmd(".", info)
 	assert.Nil(t, cmd)
-	//assert.Contains(t, "Usage: kubecmd <target>")
+	// assert.Contains(t, "Usage: kubecmd <target>")
 }
 
 func TestKubecmd_BrokenConfig(t *testing.T) {
@@ -58,7 +58,7 @@ func TestKubecmd_BrokenConfig(t *testing.T) {
 	yaml := `ci: []
 `
 	filePath := filepath.Join(name, ".buildtools.yaml")
-	_ = os.WriteFile(filePath, []byte(yaml), 0777)
+	_ = os.WriteFile(filePath, []byte(yaml), 0o777)
 
 	logMock := mocks.New()
 	log.SetHandler(logMock)
@@ -67,7 +67,8 @@ func TestKubecmd_BrokenConfig(t *testing.T) {
 	assert.Nil(t, cmd)
 	logMock.Check(t, []string{
 		fmt.Sprintf("debug: Parsing config from file: <green>'%s'</green>\n", filePath),
-		"error: yaml: unmarshal errors:\n  line 1: cannot unmarshal !!seq into config.CIConfig"})
+		"error: yaml: unmarshal errors:\n  line 1: cannot unmarshal !!seq into config.CIConfig",
+	})
 }
 
 func TestKubecmd_MissingTarget(t *testing.T) {
@@ -75,16 +76,18 @@ func TestKubecmd_MissingTarget(t *testing.T) {
 	defer func() { _ = os.RemoveAll(name) }()
 	yaml := ``
 	filePath := filepath.Join(name, ".buildtools.yaml")
-	_ = os.WriteFile(filePath, []byte(yaml), 0777)
+	_ = os.WriteFile(filePath, []byte(yaml), 0o777)
 
 	logMock := mocks.New()
 	log.SetHandler(logMock)
 	log.SetLevel(log.DebugLevel)
 	cmd := Kubecmd(name, info, "dummy")
 	assert.Nil(t, cmd)
-	logMock.Check(t, []string{fmt.Sprintf(
-		"debug: Parsing config from file: <green>'%s'</green>\n", filePath),
-		"warn: no target matching dummy found\n"})
+	logMock.Check(t, []string{
+		fmt.Sprintf(
+			"debug: Parsing config from file: <green>'%s'</green>\n", filePath),
+		"warn: no target matching dummy found\n",
+	})
 }
 
 func TestKubecmd_NoOptions(t *testing.T) {
@@ -97,7 +100,7 @@ targets:
     namespace: none
 `
 	filePath := filepath.Join(name, ".buildtools.yaml")
-	_ = os.WriteFile(filePath, []byte(yaml), 0777)
+	_ = os.WriteFile(filePath, []byte(yaml), 0o777)
 
 	logMock := mocks.New()
 	log.SetHandler(logMock)
@@ -117,7 +120,7 @@ targets:
     namespace: none
 `
 	filePath := filepath.Join(name, ".buildtools.yaml")
-	_ = os.WriteFile(filePath, []byte(yaml), 0777)
+	_ = os.WriteFile(filePath, []byte(yaml), 0o777)
 
 	logMock := mocks.New()
 	log.SetHandler(logMock)

--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -117,7 +117,7 @@ func argsFromTarget(e *config.Target, tempDir string) map[string]string {
 
 func writeKubeconfigFile(tempDir string, content []byte) (string, error) {
 	kubeconfigFile := filepath.Join(tempDir, "kubeconfig")
-	err := os.WriteFile(kubeconfigFile, content, 0777)
+	err := os.WriteFile(kubeconfigFile, content, 0o777)
 	return kubeconfigFile, err
 }
 
@@ -139,7 +139,7 @@ func (k kubectl) defaultArgs() (args []string) {
 
 func (k kubectl) Apply(input string) error {
 	file := filepath.Join(k.tempDir, "content.yaml")
-	err := os.WriteFile(file, []byte(input), 0777)
+	err := os.WriteFile(file, []byte(input), 0o777)
 	if err != nil {
 		return err
 	}

--- a/pkg/kubectl/kubectl_test.go
+++ b/pkg/kubectl/kubectl_test.go
@@ -71,6 +71,7 @@ func TestNew_NoNamespace(t *testing.T) {
 	assert.Equal(t, []string{"apply", "--context", "missing", "--file", fmt.Sprintf("%s/content.yaml", tempDir), "--v=6", "--server-side", "--force-conflicts"}, calls[0])
 	logMock.Check(t, []string{})
 }
+
 func TestNew_NoContext(t *testing.T) {
 	logMock := mocks.New()
 	log.SetHandler(logMock)
@@ -269,7 +270,6 @@ func TestKubectl_KubeconfigBase64Set(t *testing.T) {
 }
 
 func TestKubectl_KubeconfigExistingFile(t *testing.T) {
-
 	name, _ := os.CreateTemp(os.TempDir(), "kubecontent")
 	defer func() {
 		_ = os.Remove(name.Name())
@@ -419,10 +419,12 @@ Events:
 	logMock.Check(t, []string{})
 }
 
-var calls [][]string
-var cmdError *string
-var cmdOut *string
-var fatal = false
+var (
+	calls    [][]string
+	cmdError *string
+	cmdOut   *string
+	fatal    = false
+)
 
 func mockCmd(_ io.Reader, out, _ io.Writer, args []string) *cobra.Command {
 	var ctx, ns, file *string
@@ -438,7 +440,7 @@ func mockCmd(_ io.Reader, out, _ io.Writer, args []string) *cobra.Command {
 	cmd := cobra.Command{
 		Use: "kubectl",
 		Args: func(cmd *cobra.Command, args []string) error {
-			var call = args
+			call := args
 			if *ctx != "" {
 				call = append(call, "--context", *ctx)
 			}

--- a/pkg/promote/promote.go
+++ b/pkg/promote/promote.go
@@ -138,7 +138,7 @@ func Promote(dir, name, timestamp string, target *config.Gitops, args Args, cfg 
 			}
 		}
 	} else {
-		err := os.WriteFile(args.Out, buffer.Bytes(), 0666)
+		err := os.WriteFile(args.Out, buffer.Bytes(), 0o666)
 		if err != nil {
 			return err
 		}
@@ -172,11 +172,11 @@ func commitAndPush(target *config.Gitops, keys *ssh.PublicKeys, name string, buf
 	if name != normalized {
 		log.Debugf("Normalized name from %s to %s\n", name, normalized)
 	}
-	err = os.MkdirAll(filepath.Join(cloneDir, target.Path, normalized), 0777)
+	err = os.MkdirAll(filepath.Join(cloneDir, target.Path, normalized), 0o777)
 	if err != nil {
 		return err
 	}
-	err = os.WriteFile(filepath.Join(cloneDir, target.Path, normalized, "deploy.yaml"), buffer.Bytes(), 0666)
+	err = os.WriteFile(filepath.Join(cloneDir, target.Path, normalized, "deploy.yaml"), buffer.Bytes(), 0o666)
 	if err != nil {
 		return err
 	}

--- a/pkg/promote/promote_test.go
+++ b/pkg/promote/promote_test.go
@@ -336,14 +336,14 @@ data:
 			defer func() { _ = os.RemoveAll(otherrepo) }()
 
 			buff := Template(t, tt.config, repo, otherrepo)
-			err := os.WriteFile(filepath.Join(name, ".buildtools.yaml"), buff.Bytes(), 0777)
+			err := os.WriteFile(filepath.Join(name, ".buildtools.yaml"), buff.Bytes(), 0o777)
 			assert.NoError(t, err)
 
 			if tt.descriptor != "" {
 				k8s := filepath.Join(name, "k8s")
-				err = os.MkdirAll(k8s, 0777)
+				err = os.MkdirAll(k8s, 0o777)
 				assert.NoError(t, err)
-				err = os.WriteFile(filepath.Join(k8s, "descriptor.yaml"), []byte(tt.descriptor), 0666)
+				err = os.WriteFile(filepath.Join(k8s, "descriptor.yaml"), []byte(tt.descriptor), 0o666)
 				assert.NoError(t, err)
 			}
 			err = os.Chdir(name)
@@ -413,9 +413,9 @@ func TestPromote_OutParam(t *testing.T) {
 			log.SetHandler(logMock)
 			name, _ := os.MkdirTemp(os.TempDir(), "build-tools")
 			defer func() { _ = os.RemoveAll(name) }()
-			err := os.MkdirAll(filepath.Join(name, "k8s"), 0777)
+			err := os.MkdirAll(filepath.Join(name, "k8s"), 0o777)
 			assert.NoError(t, err)
-			err = os.WriteFile(filepath.Join(name, "k8s", "deploy.yaml"), []byte(`some data`), 0666)
+			err = os.WriteFile(filepath.Join(name, "k8s", "deploy.yaml"), []byte(`some data`), 0o666)
 			assert.NoError(t, err)
 			cfg := config.InitEmptyConfig()
 
@@ -428,7 +428,7 @@ func TestPromote_OutParam(t *testing.T) {
 }
 
 func generateSSHKey(t *testing.T, dir string) {
-	err := os.MkdirAll(dir, 0777)
+	err := os.MkdirAll(dir, 0o777)
 	assert.NoError(t, err)
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	assert.NoError(t, err)
@@ -462,7 +462,7 @@ func InitRepo(t *testing.T, prefix string, bare bool) (string, plumbing.Hash) {
 	assert.NoError(t, err)
 	tree, err := gitrepo.Worktree()
 	assert.NoError(t, err)
-	err = os.WriteFile(filepath.Join(repo, "file"), []byte("test"), 0666)
+	err = os.WriteFile(filepath.Join(repo, "file"), []byte("test"), 0o666)
 	assert.NoError(t, err)
 	_, err = tree.Add("file")
 	assert.NoError(t, err)

--- a/pkg/push/push_test.go
+++ b/pkg/push/push_test.go
@@ -110,8 +110,10 @@ func TestPush_NoRegistry(t *testing.T) {
 	assert.Equal(t, -6, exitCode)
 	logMock.Check(t, []string{
 		"debug: Authentication <yellow>not supported</yellow> for registry <green>No docker registry</green>\n",
-		"error: Commit and/or branch information is <red>missing</red>. Perhaps your not in a Git repository or forgot to set environment variables?"})
+		"error: Commit and/or branch information is <red>missing</red>. Perhaps your not in a Git repository or forgot to set environment variables?",
+	})
 }
+
 func TestPush_PushError(t *testing.T) {
 	defer func() { _ = os.RemoveAll(name) }()
 	_ = write(name, "Dockerfile", "FROM scratch")
@@ -157,7 +159,8 @@ func TestPush_PushFeatureBranch(t *testing.T) {
 	logMock.Check(t, []string{
 		"debug: Logged in\n",
 		"info: Pushing tag '<green>repo/reponame:abc123</green>'\n",
-		"info: Pushing tag '<green>repo/reponame:feature1</green>'\n"})
+		"info: Pushing tag '<green>repo/reponame:feature1</green>'\n",
+	})
 }
 
 func TestPush_PushMasterBranch(t *testing.T) {
@@ -178,12 +181,16 @@ func TestPush_PushMasterBranch(t *testing.T) {
 
 	assert.Equal(t, 0, exitCode)
 	assert.Equal(t, []string{
-		"repo/reponame:abc123", "repo/reponame:master", "repo/reponame:latest"}, client.Images)
-	logMock.Check(t, []string{"debug: Logged in\n",
+		"repo/reponame:abc123", "repo/reponame:master", "repo/reponame:latest",
+	}, client.Images)
+	logMock.Check(t, []string{
+		"debug: Logged in\n",
 		"info: Pushing tag '<green>repo/reponame:abc123</green>'\n",
 		"info: Pushing tag '<green>repo/reponame:master</green>'\n",
-		"info: Pushing tag '<green>repo/reponame:latest</green>'\n"})
+		"info: Pushing tag '<green>repo/reponame:latest</green>'\n",
+	})
 }
+
 func TestPush_PushMainBranch(t *testing.T) {
 	defer func() { _ = os.RemoveAll(name) }()
 	_ = write(name, "Dockerfile", "FROM scratch")
@@ -202,10 +209,12 @@ func TestPush_PushMainBranch(t *testing.T) {
 
 	assert.Equal(t, 0, exitCode)
 	assert.Equal(t, []string{"repo/reponame:abc123", "repo/reponame:main", "repo/reponame:latest"}, client.Images)
-	logMock.Check(t, []string{"debug: Logged in\n",
+	logMock.Check(t, []string{
+		"debug: Logged in\n",
 		"info: Pushing tag '<green>repo/reponame:abc123</green>'\n",
 		"info: Pushing tag '<green>repo/reponame:main</green>'\n",
-		"info: Pushing tag '<green>repo/reponame:latest</green>'\n"})
+		"info: Pushing tag '<green>repo/reponame:latest</green>'\n",
+	})
 }
 
 func TestPush_Multistage(t *testing.T) {
@@ -236,12 +245,14 @@ COPY --from=test file2 .
 
 	assert.Equal(t, 0, exitCode)
 	assert.Equal(t, []string{"repo/reponame:build", "repo/reponame:test", "repo/reponame:abc123", "repo/reponame:master", "repo/reponame:latest"}, client.Images)
-	logMock.Check(t, []string{"debug: Logged in\n",
+	logMock.Check(t, []string{
+		"debug: Logged in\n",
 		"info: Pushing tag '<green>repo/reponame:build</green>'\n",
 		"info: Pushing tag '<green>repo/reponame:test</green>'\n",
 		"info: Pushing tag '<green>repo/reponame:abc123</green>'\n",
 		"info: Pushing tag '<green>repo/reponame:master</green>'\n",
-		"info: Pushing tag '<green>repo/reponame:latest</green>'\n"})
+		"info: Pushing tag '<green>repo/reponame:latest</green>'\n",
+	})
 }
 
 func TestPush_Output(t *testing.T) {
@@ -301,10 +312,12 @@ func TestPush_Output(t *testing.T) {
 
 	assert.Equal(t, 0, exitCode)
 	assert.Equal(t, []string{"repo/reponame:abc123", "repo/reponame:master", "repo/reponame:latest"}, client.Images)
-	logMock.Check(t, []string{"debug: Logged in\n",
+	logMock.Check(t, []string{
+		"debug: Logged in\n",
 		"info: Pushing tag '<green>repo/reponame:abc123</green>'\n",
 		"info: Pushing tag '<green>repo/reponame:master</green>'\n",
-		"info: Pushing tag '<green>repo/reponame:latest</green>'\n"})
+		"info: Pushing tag '<green>repo/reponame:latest</green>'\n",
+	})
 }
 
 func TestPush_BrokenOutput(t *testing.T) {
@@ -328,7 +341,8 @@ func TestPush_BrokenOutput(t *testing.T) {
 		"debug: Logged in\n",
 		"info: Pushing tag '<green>repo/reponame:abc123</green>'\n",
 		"error: Unable to parse response: Broken output, Error: invalid character 'B' looking for beginning of value\n",
-		"error: <red>invalid character 'B' looking for beginning of value</red>"})
+		"error: <red>invalid character 'B' looking for beginning of value</red>",
+	})
 }
 
 func TestPush_ErrorDetail(t *testing.T) {
@@ -351,7 +365,8 @@ func TestPush_ErrorDetail(t *testing.T) {
 	logMock.Check(t, []string{
 		"debug: Logged in\n",
 		"info: Pushing tag '<green>repo/reponame:abc123</green>'\n",
-		"error: <red>error details</red>"})
+		"error: <red>error details</red>",
+	})
 }
 
 func TestPush_Create_Error(t *testing.T) {
@@ -373,13 +388,14 @@ func TestPush_Create_Error(t *testing.T) {
 
 	assert.Equal(t, -4, exitCode)
 	logMock.Check(t, []string{
-		"error: <red>create error</red>"})
+		"error: <red>create error</red>",
+	})
 }
 
 func TestPush_UnreadableDockerfile(t *testing.T) {
 	defer func() { _ = os.RemoveAll(name) }()
 	dockerfile := filepath.Join(name, "Dockerfile")
-	_ = os.MkdirAll(dockerfile, 0777)
+	_ = os.MkdirAll(dockerfile, 0o777)
 
 	logMock := mocks.New()
 	log.SetHandler(logMock)
@@ -396,11 +412,11 @@ func TestPush_UnreadableDockerfile(t *testing.T) {
 	assert.Equal(t, -5, exitCode)
 	logMock.Check(t, []string{
 		"debug: Logged in\n",
-		fmt.Sprintf("error: <red>read %s: is a directory</red>", dockerfile)})
+		fmt.Sprintf("error: <red>read %s: is a directory</red>", dockerfile),
+	})
 }
 
-type mockRegistry struct {
-}
+type mockRegistry struct{}
 
 func (m mockRegistry) Configured() bool {
 	return true
@@ -454,8 +470,8 @@ func (v no) Name() string {
 var _ vcs.VCS = &no{}
 
 func write(dir, file, content string) error {
-	if err := os.MkdirAll(filepath.Dir(filepath.Join(dir, file)), 0777); err != nil {
+	if err := os.MkdirAll(filepath.Dir(filepath.Join(dir, file)), 0o777); err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(dir, file), []byte(fmt.Sprintln(strings.TrimSpace(content))), 0666)
+	return os.WriteFile(filepath.Join(dir, file), []byte(fmt.Sprintln(strings.TrimSpace(content))), 0o666)
 }

--- a/pkg/registry/ecr_test.go
+++ b/pkg/registry/ecr_test.go
@@ -47,7 +47,6 @@ func TestEcr_LoginAuthRequestFailed(t *testing.T) {
 	err := registry.Login(client)
 	assert.EqualError(t, err, "auth failure")
 	logMock.Check(t, []string{})
-
 }
 
 func TestEcr_LoginInvalidAuthData(t *testing.T) {
@@ -59,7 +58,6 @@ func TestEcr_LoginInvalidAuthData(t *testing.T) {
 	err := registry.Login(client)
 	assert.EqualError(t, err, "illegal base64 data at input byte 4")
 	logMock.Check(t, []string{})
-
 }
 
 func TestEcr_LoginFailed(t *testing.T) {
@@ -71,7 +69,6 @@ func TestEcr_LoginFailed(t *testing.T) {
 	err := registry.Login(client)
 	assert.EqualError(t, err, "invalid username/password")
 	logMock.Check(t, []string{})
-
 }
 
 func TestEcr_LoginSuccess(t *testing.T) {

--- a/pkg/registry/github.go
+++ b/pkg/registry/github.go
@@ -67,6 +67,7 @@ func (r Github) password() string {
 	}
 	return r.Password
 }
+
 func (r Github) GetAuthConfig() registry.AuthConfig {
 	return registry.AuthConfig{Username: r.Username, Password: r.password(), ServerAddress: "ghcr.io"}
 }

--- a/pkg/vcs/vcs_testing.go
+++ b/pkg/vcs/vcs_testing.go
@@ -42,6 +42,7 @@ func NewMockVcsWithBranch(branch string) VCS {
 		commit: "fallback-sha",
 	}
 }
+
 func (m mockVcs) Identify(dir string) bool {
 	panic("implement me")
 }


### PR DESCRIPTION
Add the `go-fumpt` hook to the pre-commit configuration for Go
formatting. Update variable declarations in `docker.go` and `kubectl.go`
to use the short variable declaration syntax. Change file permission
mode definitions from octal literals to use the new syntax. Refactor
test output assertions in `push_test.go` to improve formatting and
readability. These changes enhance code quality and maintainability.