### PR TITLE
chore: update golang base image and go version to 1.24.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-FROM golang:1.24@sha256:10c131810f80a4802c49cab0961bbe18a16f4bb2fb99ef16deaa23e4246fc817 as go-build
+FROM amd64/golang:1.24.4@sha256:3494bbe140127d12656113203ec91b8e3ff34e8a2b06a0a22bb0d8a41cc69e53 as go-build
 
 RUN go install sigs.k8s.io/aws-iam-authenticator/cmd/aws-iam-authenticator@v0.7.2
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildtool/build-tools
 
-go 1.24.2
+go 1.24.4
 
 require (
 	dario.cat/mergo v1.0.2


### PR DESCRIPTION
Updates the Dockerfile to use the amd64/golang:1.24.4 image and 
modifies the go.mod file to reflect the updated Go version from 
1.24.2 to 1.24.4. This ensures compatibility with the latest 
features and fixes provided in the newer Go release.