### PR TITLE
fix(go): update Go version from 1.24.4 to 1.24.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildtool/build-tools
 
-go 1.24.4
+go 1.24.6
 
 require (
 	dario.cat/mergo v1.0.2


### PR DESCRIPTION
Updates the Go version in the go.mod file to address  
security vulnerabilities and improve performance. This  
ensures compatibility with recent dependency updates  
and takes advantage of the latest language features.