### PR TITLE
ci: bump Go version to 1.25.1 from 1.24.4

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,4 +51,7 @@ repos:
       - id: go-imports
       - id: go-test-mod
       - id: go-fumpt
-      - id: golangci-lint-mod
+  - repo: https://github.com/golangci/golangci-lint
+    rev: v2.5.0
+    hooks:
+    - id: golangci-lint-full

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildtool/build-tools
 
-go 1.24.4
+go 1.25.1
 
 require (
 	dario.cat/mergo v1.0.2


### PR DESCRIPTION
Updates the Go version in the module definition to 1.25.1. This change 
ensures compatibility with new features and improvements in the Go 
language, enhancing performance and security in the project.