### PR TITLE
feat(ci): improve BuildName method to handle self-hosted runner path

### DIFF
--- a/pkg/ci/github.go
+++ b/pkg/ci/github.go
@@ -23,6 +23,7 @@
 package ci
 
 import (
+	"path/filepath"
 	"strings"
 )
 
@@ -44,7 +45,11 @@ func (c *Github) BranchReplaceSlash() string {
 }
 
 func (c *Github) BuildName() string {
-	return c.Common.BuildName(strings.TrimPrefix(c.CIBuildName, "/home/runner/work/"))
+	if c.CIBuildName != "" {
+		return c.Common.BuildName(filepath.Base(c.CIBuildName))
+	} else {
+		return c.Common.BuildName(c.CIBuildName)
+	}
 }
 
 func (c *Github) Branch() string {
@@ -62,5 +67,5 @@ func (c *Github) Commit() string {
 }
 
 func (c *Github) Configured() bool {
-	return c.CIBuildName != ""
+	return c.CICommit != ""
 }


### PR DESCRIPTION
Enhance the BuildName function to handle CIBuildName correctly by 
using filepath.Base when it is non-empty. Update the Configured 
function to check CICommit instead of CIBuildName for more accurate 
configuration validation.
`RUNNER_WORKSPACE` differ between GitHub hosted runners and our self-hosted.