### PR TITLE
chore(go): update Go version to 1.25.3 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildtool/build-tools
 
-go 1.25.1
+go 1.25.3
 
 require (
 	dario.cat/mergo v1.0.2


### PR DESCRIPTION
Updates the Go version in the go.mod file from 1.25.1 to 1.25.3 to
ensure compatibility with recent changes and improvements in the Go
language.