### PR TITLE
feat(build): add support for multi-platform docker builds

### DIFF
--- a/pkg/docker/auth_test.go
+++ b/pkg/docker/auth_test.go
@@ -24,11 +24,17 @@ package docker
 
 import (
 	"context"
+	"errors"
+	"net/http"
 	"testing"
+	"time"
 
+	authutil "github.com/containerd/containerd/v2/core/remotes/docker/auth"
 	"github.com/docker/docker/api/types/registry"
 	auth2 "github.com/moby/buildkit/session/auth"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 )
 
 func Test_Credentials(t *testing.T) {
@@ -45,4 +51,339 @@ func Test_Credentials(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "user", creds.Username)
 	require.Equal(t, "password", creds.Secret)
+}
+
+func Test_Credentials_WithPath(t *testing.T) {
+	// When registryHost contains a path (e.g., GitLab registry),
+	// but the request only contains the hostname
+	authWithPath := NewAuthenticator("registry.gitlab.com/org/repo", registry.AuthConfig{
+		Username: "gitlab-ci-token",
+		Password: "token123",
+	})
+
+	// Request with just the hostname should still match
+	creds, err := authWithPath.Credentials(context.TODO(), &auth2.CredentialsRequest{Host: "registry.gitlab.com"})
+	require.NoError(t, err)
+	require.Equal(t, "gitlab-ci-token", creds.Username)
+	require.Equal(t, "token123", creds.Secret)
+
+	// Exact match should also work
+	authExact := NewAuthenticator("registry.gitlab.com", registry.AuthConfig{
+		Username: "user",
+		Password: "pass",
+	})
+	creds, err = authExact.Credentials(context.TODO(), &auth2.CredentialsRequest{Host: "registry.gitlab.com"})
+	require.NoError(t, err)
+	require.Equal(t, "user", creds.Username)
+	require.Equal(t, "pass", creds.Secret)
+
+	// Different registry should not match
+	creds, err = authWithPath.Credentials(context.TODO(), &auth2.CredentialsRequest{Host: "ghcr.io"})
+	require.NoError(t, err)
+	require.Equal(t, "", creds.Username)
+	require.Equal(t, "", creds.Secret)
+}
+
+func Test_GetRegistryHost(t *testing.T) {
+	auth := NewAuthenticator("registry.example.com/org/repo", registry.AuthConfig{
+		Username: "user",
+		Password: "pass",
+	})
+
+	// Type assert to access GetRegistryHost
+	a, ok := auth.(*authenticator)
+	require.True(t, ok)
+	assert.Equal(t, "registry.example.com/org/repo", a.GetRegistryHost())
+}
+
+func Test_Register(t *testing.T) {
+	auth := NewAuthenticator("registry.example.com", registry.AuthConfig{
+		Username: "user",
+		Password: "pass",
+	})
+
+	server := grpc.NewServer()
+	// Should not panic
+	auth.Register(server)
+	server.Stop()
+}
+
+func Test_GetTokenAuthority(t *testing.T) {
+	auth := NewAuthenticator("registry.example.com", registry.AuthConfig{
+		Username: "user",
+		Password: "pass",
+	})
+
+	salt := []byte("test-salt-value")
+	resp, err := auth.GetTokenAuthority(context.TODO(), &auth2.GetTokenAuthorityRequest{
+		Host: "registry.example.com",
+		Salt: salt,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	// Public key should be 32 bytes (ed25519 public key)
+	assert.Len(t, resp.PublicKey, 32)
+}
+
+func Test_VerifyTokenAuthority(t *testing.T) {
+	auth := NewAuthenticator("registry.example.com", registry.AuthConfig{
+		Username: "user",
+		Password: "pass",
+	})
+
+	salt := []byte("test-salt-value")
+	payload := []byte("test-payload")
+
+	resp, err := auth.VerifyTokenAuthority(context.TODO(), &auth2.VerifyTokenAuthorityRequest{
+		Host:    "registry.example.com",
+		Salt:    salt,
+		Payload: payload,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	// Signed response should be longer than payload (signature + payload)
+	assert.Greater(t, len(resp.Signed), len(payload))
+}
+
+func Test_GetTokenAuthority_ConsistentKeys(t *testing.T) {
+	auth := NewAuthenticator("registry.example.com", registry.AuthConfig{
+		Username: "user",
+		Password: "pass",
+	})
+
+	salt := []byte("test-salt")
+
+	// Same salt should produce same public key
+	resp1, err := auth.GetTokenAuthority(context.TODO(), &auth2.GetTokenAuthorityRequest{
+		Host: "registry.example.com",
+		Salt: salt,
+	})
+	require.NoError(t, err)
+
+	resp2, err := auth.GetTokenAuthority(context.TODO(), &auth2.GetTokenAuthorityRequest{
+		Host: "registry.example.com",
+		Salt: salt,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, resp1.PublicKey, resp2.PublicKey)
+
+	// Different salt should produce different public key
+	resp3, err := auth.GetTokenAuthority(context.TODO(), &auth2.GetTokenAuthorityRequest{
+		Host: "registry.example.com",
+		Salt: []byte("different-salt"),
+	})
+	require.NoError(t, err)
+
+	assert.NotEqual(t, resp1.PublicKey, resp3.PublicKey)
+}
+
+func Test_toTokenResponse(t *testing.T) {
+	tests := []struct {
+		name      string
+		token     string
+		issuedAt  time.Time
+		expires   int
+		wantToken string
+		wantExp   int64
+		wantIssAt int64
+	}{
+		{
+			name:      "with all fields",
+			token:     "test-token",
+			issuedAt:  time.Unix(1000, 0),
+			expires:   3600,
+			wantToken: "test-token",
+			wantExp:   3600,
+			wantIssAt: 1000,
+		},
+		{
+			name:      "with zero issued at",
+			token:     "another-token",
+			issuedAt:  time.Time{},
+			expires:   7200,
+			wantToken: "another-token",
+			wantExp:   7200,
+			wantIssAt: 0,
+		},
+		{
+			name:      "empty token",
+			token:     "",
+			issuedAt:  time.Unix(500, 0),
+			expires:   0,
+			wantToken: "",
+			wantExp:   0,
+			wantIssAt: 500,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := toTokenResponse(tt.token, tt.issuedAt, tt.expires)
+
+			assert.Equal(t, tt.wantToken, resp.Token)
+			assert.Equal(t, tt.wantExp, resp.ExpiresIn)
+			assert.Equal(t, tt.wantIssAt, resp.IssuedAt)
+		})
+	}
+}
+
+func Test_getAuthorityKey(t *testing.T) {
+	auth := &authenticator{
+		registryHost: "registry.example.com",
+		authConfig: registry.AuthConfig{
+			Username: "user",
+			Password: "pass",
+		},
+	}
+
+	salt := []byte("test-salt")
+	key := auth.getAuthorityKey("registry.example.com", salt)
+
+	// ed25519 private key should be 64 bytes
+	assert.Len(t, key, 64)
+
+	// Same inputs should produce same key
+	key2 := auth.getAuthorityKey("registry.example.com", salt)
+	assert.Equal(t, key, key2)
+
+	// Different salt should produce different key
+	key3 := auth.getAuthorityKey("registry.example.com", []byte("other-salt"))
+	assert.NotEqual(t, key, key3)
+}
+
+func Test_FetchToken_Success(t *testing.T) {
+	mockFetcher := func(_ context.Context, _ *http.Client, _ http.Header, to authutil.TokenOptions) (*authutil.FetchTokenResponse, error) {
+		return &authutil.FetchTokenResponse{
+			Token:            "mock-token",
+			IssuedAt:         time.Unix(1000, 0),
+			ExpiresInSeconds: 3600,
+		}, nil
+	}
+
+	auth := NewAuthenticatorWithTokenFetcher("registry.example.com", registry.AuthConfig{
+		Username: "user",
+		Password: "pass",
+	}, mockFetcher)
+
+	resp, err := auth.FetchToken(context.TODO(), &auth2.FetchTokenRequest{
+		Realm:   "https://registry.example.com/token",
+		Service: "registry",
+		Scopes:  []string{"repository:image:pull,push"},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "mock-token", resp.Token)
+	assert.Equal(t, int64(3600), resp.ExpiresIn)
+	assert.Equal(t, int64(1000), resp.IssuedAt)
+}
+
+func Test_FetchToken_WithCredentials(t *testing.T) {
+	var capturedOptions authutil.TokenOptions
+
+	mockFetcher := func(_ context.Context, _ *http.Client, _ http.Header, to authutil.TokenOptions) (*authutil.FetchTokenResponse, error) {
+		capturedOptions = to
+		return &authutil.FetchTokenResponse{
+			Token: "auth-token",
+		}, nil
+	}
+
+	auth := NewAuthenticatorWithTokenFetcher("registry.example.com", registry.AuthConfig{
+		Username: "myuser",
+		Password: "mypass",
+	}, mockFetcher)
+
+	_, err := auth.FetchToken(context.TODO(), &auth2.FetchTokenRequest{
+		Realm:   "https://registry.example.com/token",
+		Service: "registry",
+		Scopes:  []string{"repository:image:pull"},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "myuser", capturedOptions.Username)
+	assert.Equal(t, "mypass", capturedOptions.Secret)
+}
+
+func Test_FetchToken_AnonymousFallback(t *testing.T) {
+	callCount := 0
+	var capturedOptionsOnRetry authutil.TokenOptions
+
+	mockFetcher := func(_ context.Context, _ *http.Client, _ http.Header, to authutil.TokenOptions) (*authutil.FetchTokenResponse, error) {
+		callCount++
+		if callCount == 1 {
+			// First call with credentials fails
+			return nil, errors.New("unauthorized")
+		}
+		// Second call (anonymous) succeeds
+		capturedOptionsOnRetry = to
+		return &authutil.FetchTokenResponse{
+			Token: "anonymous-token",
+		}, nil
+	}
+
+	auth := NewAuthenticatorWithTokenFetcher("registry.example.com", registry.AuthConfig{
+		Username: "user",
+		Password: "pass",
+	}, mockFetcher)
+
+	resp, err := auth.FetchToken(context.TODO(), &auth2.FetchTokenRequest{
+		Realm:   "https://registry.example.com/token",
+		Service: "registry",
+		Scopes:  []string{"repository:image:pull"},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "anonymous-token", resp.Token)
+	assert.Equal(t, 2, callCount)
+	// On retry, credentials should be cleared
+	assert.Equal(t, "", capturedOptionsOnRetry.Username)
+	assert.Equal(t, "", capturedOptionsOnRetry.Secret)
+}
+
+func Test_FetchToken_AllFailures(t *testing.T) {
+	mockFetcher := func(_ context.Context, _ *http.Client, _ http.Header, to authutil.TokenOptions) (*authutil.FetchTokenResponse, error) {
+		return nil, errors.New("network error")
+	}
+
+	auth := NewAuthenticatorWithTokenFetcher("registry.example.com", registry.AuthConfig{
+		Username: "user",
+		Password: "pass",
+	}, mockFetcher)
+
+	_, err := auth.FetchToken(context.TODO(), &auth2.FetchTokenRequest{
+		Realm:   "https://registry.example.com/token",
+		Service: "registry",
+		Scopes:  []string{"repository:image:pull"},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to fetch token")
+}
+
+func Test_FetchToken_NoCredentials(t *testing.T) {
+	var capturedOptions authutil.TokenOptions
+
+	mockFetcher := func(_ context.Context, _ *http.Client, _ http.Header, to authutil.TokenOptions) (*authutil.FetchTokenResponse, error) {
+		capturedOptions = to
+		return &authutil.FetchTokenResponse{
+			Token: "anon-token",
+		}, nil
+	}
+
+	// No credentials provided
+	auth := NewAuthenticatorWithTokenFetcher("registry.example.com", registry.AuthConfig{}, mockFetcher)
+
+	resp, err := auth.FetchToken(context.TODO(), &auth2.FetchTokenRequest{
+		Realm:   "https://registry.example.com/token",
+		Service: "registry",
+		Scopes:  []string{"repository:image:pull"},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "anon-token", resp.Token)
+	// Should not have credentials
+	assert.Equal(t, "", capturedOptions.Username)
+	assert.Equal(t, "", capturedOptions.Secret)
 }

--- a/www/docs/commands/build.md
+++ b/www/docs/commands/build.md
@@ -3,13 +3,13 @@
 Performs a `docker build`, using a `Dockerfile` to build the application and tags the resulting image. By following the
 conventions no additional flags are needed, but the following flags are available:
 
-| Flag                                 | Description                                                                                                                                             |
-|:-------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `--file`,`-f` `<path to Dockerfile>` | Used to override the default `Dockerfile` location (which is `$PWD`), or `-` to read from `stdin                                                        |
-| `--no-login`                         | Disables login to docker registry (good for local testing)                                                                                              |
-| `--no-pull`                          | Disables pulling of remote images if they already exist (good for local testing)                                                                        |
-| `--build-arg key=value`              | Additional Docker [build-arg](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg)                         |
-| `--platform value`                   | Specify target architecture [architecture](https://docs.docker.com/desktop/multi-arch/). should be a single string for example `--platform linux/amd64` |
+| Flag                                 | Description                                                                                                                                                                                                                                                 |
+|:-------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--file`,`-f` `<path to Dockerfile>` | Used to override the default `Dockerfile` location (which is `$PWD`), or `-` to read from `stdin                                                                                                                                                            |
+| `--no-login`                         | Disables login to docker registry (good for local testing)                                                                                                                                                                                                  |
+| `--no-pull`                          | Disables pulling of remote images if they already exist (good for local testing)                                                                                                                                                                            |
+| `--build-arg key=value`              | Additional Docker [build-arg](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg)                                                                                                                             |
+| `--platform value`                   | Specify target platform(s) for [multi-arch builds](https://docs.docker.com/desktop/multi-arch/). Single platform: `--platform linux/amd64` or multiple platforms: `--platform linux/amd64,linux/arm64`. Multi-platform builds are pushed directly to registry. |
 
 ```sh
 $ build --file docker/Dockerfile.build --skip-login --build-arg AUTH_TOKEN=abc
@@ -92,3 +92,98 @@ text to be copied to localhost
 ```
 
 [Custom build outputs]: (https://docs.docker.com/engine/reference/commandline/build/#custom-build-outputs)
+
+## Multi-platform builds
+
+Build-tools supports building Docker images for multiple platforms (architectures) simultaneously using buildkit's native multi-platform support. This is useful for creating images that can run on different architectures like AMD64, ARM64, ARM/v7, etc.
+
+### Basic usage
+
+To build for multiple platforms, provide a comma-separated list of platform identifiers:
+
+```shell
+$ build --platform linux/amd64,linux/arm64
+```
+
+Common platforms:
+- `linux/amd64` - 64-bit x86 (Intel/AMD)
+- `linux/arm64` - 64-bit ARM (Apple Silicon, ARM servers)
+- `linux/arm/v7` - 32-bit ARM (Raspberry Pi 3+, older ARM devices)
+- `linux/arm/v6` - 32-bit ARM (Raspberry Pi 1/2, older ARM devices)
+
+### How it works
+
+Multi-platform builds:
+1. Build the image for all specified platforms in parallel using buildkit
+2. Create a manifest list that references all platform-specific images
+3. Push directly to the configured registry (multi-platform manifests cannot be loaded to local Docker daemon)
+4. Tag all platform images with the same tags (commit, branch, latest if applicable)
+
+**Important notes:**
+- Multi-platform builds require buildkit (Docker 19.03+)
+- Images are automatically pushed to the registry during the build process
+- You may need QEMU for cross-platform emulation if building on a single architecture
+- Multi-platform builds are typically slower than single-platform builds
+
+### Example
+
+```shell
+# Build for AMD64 and ARM64
+$ build --platform linux/amd64,linux/arm64
+
+# The built images will be pushed to the registry with manifest list support
+# Clients pulling the image will automatically get the correct architecture
+```
+
+### Requirements
+
+**Option 1: Use a standalone BuildKit instance (recommended)**
+
+Set the `BUILDKIT_HOST` environment variable to connect directly to a buildkit instance:
+
+```shell
+# Example: connect to buildkit running in a container
+export BUILDKIT_HOST=docker-container://buildkitd
+
+# Example: connect to buildkit via TCP
+export BUILDKIT_HOST=tcp://localhost:1234
+
+# Example: connect to buildkit via Unix socket
+export BUILDKIT_HOST=unix:///run/buildkit/buildkitd.sock
+```
+
+You can run a standalone buildkit container:
+
+```shell
+docker run -d --name buildkitd --privileged moby/buildkit:latest
+```
+
+**Option 2: Enable containerd snapshotter in Docker**
+
+If not using `BUILDKIT_HOST`, multi-platform builds require Docker to be configured with the **containerd snapshotter**. This is because Docker's default storage driver doesn't support the image exporter needed for multi-platform manifest lists.
+
+Enable it by adding to `/etc/docker/daemon.json`:
+
+```json
+{
+  "features": {
+    "containerd-snapshotter": true
+  }
+}
+```
+
+Then restart Docker:
+
+```shell
+sudo systemctl restart docker
+```
+
+**QEMU for Cross-Platform Emulation:**
+
+For cross-platform builds (e.g., building ARM on x86), you may need to set up QEMU:
+
+```shell
+docker run --privileged --rm tonistiigi/binfmt --install all
+```
+
+This is typically pre-configured in most CI/CD environments (GitHub Actions, GitLab CI, etc.).


### PR DESCRIPTION
Enhance the platform argument to support multiple platforms for Docker 
builds by allowing a comma-separated list of platforms. Add helper 
methods to detect multi-platform builds and adjust build output to push 
images directly to the registry. Update logging to reflect the number 
of platforms being built. Document the new functionality in CLAUDE.md.