### PR TITLE
fix: update go version to 1.25.5 in go.mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildtool/build-tools
 
-go 1.25.3
+go 1.25.5
 
 require (
 	dario.cat/mergo v1.0.2


### PR DESCRIPTION
Updates the Go version from 1.25.3 to 1.25.5 to ensure
compatibility with the latest features and security
improvements in the Go programming language.