### PR TITLE
chore: update govulncheck-action to version 1.1.1

### DIFF
--- a/.github/workflows/govuln.yaml
+++ b/.github/workflows/govuln.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-      - uses: opzkit/govulncheck-action@27322645d1488084694992e55cde6580fa0e26a6 # v1
+      - uses: opzkit/govulncheck-action@f522a4de778cf9f398be705615b86addf059f594 # v1.1.1
         with:
           go-version-file: 'go.mod'
           check-latest: 'true'


### PR DESCRIPTION
Updates the govulncheck-action in the GitHub workflow to the 
latest version for improved security and performance. This 
change ensures that the workflow utilizes the latest fixes 
and features available in version 1.1.1.