### PR TITLE
chore(build): enhance multi-platform build support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,13 +123,15 @@ The build system supports building Docker images for multiple platforms (archite
 - Tests: `pkg/build/build_test.go:451-532`
 
 **Architecture Note**:
-- Single-platform builds use Docker's `/build` API with buildkit backend
-- Multi-platform builds use buildkit client directly via `client.Solve()`
-- Connection priority for multi-platform:
-  1. If `BUILDKIT_HOST` env var is set, connect directly to that buildkit instance
-  2. Otherwise, connect via Docker's `/grpc` endpoint (requires containerd snapshotter)
+- When `BUILDKIT_HOST` is set:
+  - All builds (single and multi-platform) use buildkit client directly via `client.Solve()`
+  - Images are pushed to registry during build
+  - The `push` command becomes a no-op (images already pushed)
+- When `BUILDKIT_HOST` is NOT set:
+  - Single-platform builds use Docker's `/build` API with buildkit backend (loads to local daemon)
+  - Multi-platform builds connect via Docker's `/grpc` endpoint (requires containerd snapshotter)
 - This is necessary because Docker's `/build` API only accepts single platform values
-- The `buildMultiPlatform()` function in `pkg/build/build.go` handles this
+- The `buildMultiPlatform()` function in `pkg/build/build.go` handles buildkit client builds
 
 ## Dependencies
 - Go 1.25.3+

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -1223,6 +1223,7 @@ func Test_buildFrontendAttrs(t *testing.T) {
 		name       string
 		dockerfile string
 		platform   string
+		target     string
 		buildArgs  map[string]*string
 		want       map[string]string
 	}{
@@ -1230,6 +1231,7 @@ func Test_buildFrontendAttrs(t *testing.T) {
 			name:       "basic attributes",
 			dockerfile: "Dockerfile",
 			platform:   "linux/amd64",
+			target:     "",
 			buildArgs:  nil,
 			want: map[string]string{
 				"filename": "Dockerfile",
@@ -1240,6 +1242,7 @@ func Test_buildFrontendAttrs(t *testing.T) {
 			name:       "with build args",
 			dockerfile: "Dockerfile.prod",
 			platform:   "linux/amd64,linux/arm64",
+			target:     "",
 			buildArgs: map[string]*string{
 				"VERSION": strPtr("1.0.0"),
 				"DEBUG":   strPtr("true"),
@@ -1255,6 +1258,7 @@ func Test_buildFrontendAttrs(t *testing.T) {
 			name:       "with nil build arg value",
 			dockerfile: "Dockerfile",
 			platform:   "linux/arm64",
+			target:     "",
 			buildArgs: map[string]*string{
 				"SET":   strPtr("value"),
 				"UNSET": nil,
@@ -1269,17 +1273,45 @@ func Test_buildFrontendAttrs(t *testing.T) {
 			name:       "empty platform",
 			dockerfile: "Dockerfile",
 			platform:   "",
+			target:     "",
 			buildArgs:  nil,
 			want: map[string]string{
 				"filename": "Dockerfile",
 				"platform": "",
 			},
 		},
+		{
+			name:       "with target stage",
+			dockerfile: "Dockerfile",
+			platform:   "linux/amd64",
+			target:     "builder",
+			buildArgs:  nil,
+			want: map[string]string{
+				"filename": "Dockerfile",
+				"platform": "linux/amd64",
+				"target":   "builder",
+			},
+		},
+		{
+			name:       "with target and build args",
+			dockerfile: "Dockerfile",
+			platform:   "linux/amd64,linux/arm64",
+			target:     "production",
+			buildArgs: map[string]*string{
+				"VERSION": strPtr("2.0.0"),
+			},
+			want: map[string]string{
+				"filename":          "Dockerfile",
+				"platform":          "linux/amd64,linux/arm64",
+				"target":            "production",
+				"build-arg:VERSION": "2.0.0",
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := buildFrontendAttrs(tt.dockerfile, tt.platform, tt.buildArgs)
+			got := buildFrontendAttrs(tt.dockerfile, tt.platform, tt.target, tt.buildArgs)
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -1459,6 +1491,7 @@ func Test_buildMultiPlatformWithFactory_Success(t *testing.T) {
 		map[string]*string{"VERSION": strPtr("1.0.0")},
 		[]string{"registry.example.com/image:v1", "registry.example.com/image:latest"},
 		[]string{"registry.example.com/image:cache"},
+		"",
 		nil,
 		mockFactory,
 	)
@@ -1489,6 +1522,7 @@ func Test_buildMultiPlatformWithFactory_ClientConnectionError(t *testing.T) {
 		nil,
 		[]string{"registry.example.com/image:v1"},
 		nil,
+		"",
 		nil,
 		mockFactory,
 	)
@@ -1522,6 +1556,7 @@ func Test_buildMultiPlatformWithFactory_SolveError(t *testing.T) {
 		nil,
 		[]string{"registry.example.com/image:v1"},
 		nil,
+		"",
 		nil,
 		mockFactory,
 	)
@@ -1558,6 +1593,7 @@ func Test_buildMultiPlatformWithFactory_ExporterNotFoundError(t *testing.T) {
 		nil,
 		[]string{"registry.example.com/image:v1"},
 		nil,
+		"",
 		nil,
 		mockFactory,
 	)
@@ -1589,6 +1625,7 @@ func Test_buildMultiPlatformWithFactory_InvalidDirectory(t *testing.T) {
 		nil,
 		[]string{"registry.example.com/image:v1"},
 		nil,
+		"",
 		nil,
 		mockFactory,
 	)
@@ -1629,6 +1666,7 @@ func Test_buildMultiPlatformWithFactory_ViaDocker(t *testing.T) {
 		nil,
 		[]string{"registry.example.com/image:v1"},
 		nil,
+		"",
 		nil,
 		mockFactory,
 	)
@@ -1661,6 +1699,7 @@ func Test_buildMultiPlatformWithFactory_ListWorkersError(t *testing.T) {
 		nil,
 		[]string{"registry.example.com/image:v1"},
 		nil,
+		"",
 		nil,
 		mockFactory,
 	)

--- a/pkg/push/push.go
+++ b/pkg/push/push.go
@@ -69,6 +69,12 @@ func Push(dir string, info version.Info, osArgs ...string) int {
 }
 
 func doPush(client docker.Client, cfg *config.Config, dir, dockerfile string) int {
+	// If BUILDKIT_HOST is set, images are pushed during build, so push is a no-op
+	if os.Getenv("BUILDKIT_HOST") != "" {
+		log.Info("BUILDKIT_HOST is set - images were pushed during build, skipping push")
+		return 0
+	}
+
 	currentCI := cfg.CurrentCI()
 	currentRegistry := cfg.CurrentRegistry()
 

--- a/www/docs/commands/build.md
+++ b/www/docs/commands/build.md
@@ -158,6 +158,9 @@ You can run a standalone buildkit container:
 docker run -d --name buildkitd --privileged moby/buildkit:latest
 ```
 
+!!! note "BUILDKIT_HOST behavior"
+    When `BUILDKIT_HOST` is set, **all builds** (single-platform and multi-platform) use the buildkit client directly. Images are pushed to the registry during the build, so the `push` command becomes a no-op.
+
 **Option 2: Enable containerd snapshotter in Docker**
 
 If not using `BUILDKIT_HOST`, multi-platform builds require Docker to be configured with the **containerd snapshotter**. This is because Docker's default storage driver doesn't support the image exporter needed for multi-platform manifest lists.


### PR DESCRIPTION
Add target parameter to multi-platform build functions to allow 
specifying the target stage for builds. Update logic to use 
BuildKit client directly when BUILDKIT_HOST is set, enabling 
images to be pushed during the build process. Skip push 
operations when BUILDKIT_HOST is defined, optimizing the 
workflow for container image management. Update related test 
cases to include target stage processing.