### PR TITLE
feat(cache): add ECR support for layer caching in buildkit

### DIFF
--- a/pkg/registry/ecr.go
+++ b/pkg/registry/ecr.go
@@ -131,7 +131,7 @@ func (r *ECR) Login(client docker.Client) error {
 }
 
 func (r *ECR) GetAuthConfig() registry.AuthConfig {
-	return registry.AuthConfig{Username: r.username, Password: r.password}
+	return registry.AuthConfig{Username: r.username, Password: r.password, ServerAddress: r.Url}
 }
 
 func (r *ECR) GetAuthInfo() string {

--- a/pkg/registry/ecr_test.go
+++ b/pkg/registry/ecr_test.go
@@ -88,7 +88,8 @@ func TestEcr_LoginSuccess(t *testing.T) {
 func TestEcr_GetAuthInfo(t *testing.T) {
 	registry := &ECR{Url: "ecr-url", Region: "eu-west-1", username: "AWS", password: "abc123"}
 	auth := registry.GetAuthInfo()
-	assert.Equal(t, "eyJ1c2VybmFtZSI6IkFXUyIsInBhc3N3b3JkIjoiYWJjMTIzIn0=", auth)
+	// Base64 of {"username":"AWS","password":"abc123","serveraddress":"ecr-url"}
+	assert.Equal(t, "eyJ1c2VybmFtZSI6IkFXUyIsInBhc3N3b3JkIjoiYWJjMTIzIiwic2VydmVyYWRkcmVzcyI6ImVjci11cmwifQ==", auth)
 }
 
 func TestEcr_RegistryAndClientInDifferentAccounts(t *testing.T) {


### PR DESCRIPTION
Introduce configuration options for AWS ECR as a remote layer cache  
backend in buildkit builds. Update the documentation and code to  
support caching layer configuration, improve build speed, and allow  
for better management of build artifacts.