### PR TITLE
fix(build): conditionally set platform attribute in build

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -328,7 +328,10 @@ func buildStage(dkrClient docker.Client, dir string, buildVars Args, buildArgs m
 func buildFrontendAttrs(dockerfile, platform, target string, buildArgs map[string]*string) map[string]string {
 	attrs := map[string]string{
 		"filename": dockerfile,
-		"platform": platform,
+	}
+
+	if platform != "" {
+		attrs["platform"] = platform
 	}
 
 	if target != "" {

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -1278,7 +1278,6 @@ func Test_buildFrontendAttrs(t *testing.T) {
 			buildArgs:  nil,
 			want: map[string]string{
 				"filename": "Dockerfile",
-				"platform": "",
 			},
 		},
 		{


### PR DESCRIPTION
Remove the default empty value for the platform key in the build map. 
Add logic to only include the platform attribute when it is not an 
empty string. This improves data handling by ensuring the platform 
key is included only when relevant.