### PR TITLE
feat(registry): add support for Gitea container registry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Each command in `cmd/` (build, push, deploy, promote, kubecmd) is a standalone C
 - `pkg/config` - Configuration loading and parsing. Loads `.buildtools.yaml` files hierarchically from current directory up to root. Merges multiple config files together. Contains `Config` struct that coordinates VCS, CI, and Registry configurations.
 - `pkg/vcs` - Version control system abstraction (currently Git-focused)
 - `pkg/ci` - CI/CD platform integrations (Azure, Buildkite, GitLab, GitHub Actions, TeamCity). Each CI provider implements the `ci.CI` interface.
-- `pkg/registry` - Docker registry integrations (Dockerhub, ACR, ECR, GCR, GitHub, GitLab, Quay). Each registry implements the `registry.Registry` interface.
+- `pkg/registry` - Docker registry integrations (Dockerhub, ACR, ECR, GCR, GitHub, GitLab, Gitea, Quay). Each registry implements the `registry.Registry` interface.
 
 **Implementation Packages**:
 - `pkg/build` - Docker image building using buildkit
@@ -92,7 +92,7 @@ Each command in `cmd/` (build, push, deploy, promote, kubecmd) is a standalone C
 The configuration file defines:
 - `vcs`: Version control settings
 - `ci`: CI platform credentials (azure, buildkite, gitlab, github, teamcity)
-- `registry`: Registry credentials (dockerhub, acr, ecr, gcr, github, gitlab, quay)
+- `registry`: Registry credentials (dockerhub, acr, ecr, gcr, github, gitlab, gitea, quay)
 - `cache`: Layer cache configuration (ecr)
 - `targets`: Kubernetes deployment targets (context, namespace, kubeconfig)
 - `git`: Git user configuration for commits (used by promote command)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -74,6 +74,7 @@ type RegistryConfig struct {
 	ECR       *registry.ECR       `yaml:"ecr"`
 	Github    *registry.Github    `yaml:"github"`
 	Gitlab    *registry.Gitlab    `yaml:"gitlab"`
+	Gitea     *registry.Gitea     `yaml:"gitea"`
 	Quay      *registry.Quay      `yaml:"quay"`
 	GCR       *registry.GCR       `yaml:"gcr"`
 }
@@ -217,6 +218,7 @@ func InitEmptyConfig() *Config {
 			ECR:       &registry.ECR{},
 			Github:    &registry.Github{},
 			Gitlab:    &registry.Gitlab{},
+			Gitea:     &registry.Gitea{},
 			Quay:      &registry.Quay{},
 			GCR:       &registry.GCR{},
 		},
@@ -225,7 +227,7 @@ func InitEmptyConfig() *Config {
 		},
 	}
 	c.AvailableCI = []ci.CI{c.CI.Azure, c.CI.Buildkite, c.CI.Gitlab, c.CI.TeamCity, c.CI.Github}
-	c.AvailableRegistries = []registry.Registry{c.Registry.Dockerhub, c.Registry.ACR, c.Registry.ECR, c.Registry.Github, c.Registry.Gitlab, c.Registry.Quay, c.Registry.GCR}
+	c.AvailableRegistries = []registry.Registry{c.Registry.Dockerhub, c.Registry.ACR, c.Registry.ECR, c.Registry.Github, c.Registry.Gitlab, c.Registry.Gitea, c.Registry.Quay, c.Registry.GCR}
 	return c
 }
 

--- a/pkg/registry/gitea.go
+++ b/pkg/registry/gitea.go
@@ -1,0 +1,87 @@
+// MIT License
+//
+// Copyright (c) 2026 buildtool
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package registry
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/apex/log"
+	"github.com/docker/docker/api/types/registry"
+
+	"github.com/buildtool/build-tools/pkg/docker"
+)
+
+type Gitea struct {
+	dockerRegistry `yaml:"-"`
+	Registry       string `yaml:"registry" env:"GITEA_REGISTRY"`
+	Username       string `yaml:"username" env:"GITEA_USERNAME"`
+	Token          string `yaml:"token,omitempty" env:"GITEA_TOKEN"`
+	Repository     string `yaml:"repository" env:"GITEA_REPOSITORY"`
+}
+
+var _ Registry = &Gitea{}
+
+func (r Gitea) Name() string {
+	return "Gitea"
+}
+
+func (r Gitea) Configured() bool {
+	return len(r.Repository) > 0 || len(r.Registry) > 0
+}
+
+func (r Gitea) Login(client docker.Client) error {
+	if ok, err := client.RegistryLogin(context.Background(), r.GetAuthConfig()); err == nil {
+		log.Debugf("%s\n", ok.Status)
+		return nil
+	} else {
+		return err
+	}
+}
+
+func (r Gitea) GetAuthConfig() registry.AuthConfig {
+	return registry.AuthConfig{Username: r.Username, Password: r.Token, ServerAddress: r.Registry}
+}
+
+func (r Gitea) GetAuthInfo() string {
+	authBytes, _ := json.Marshal(r.GetAuthConfig())
+	return base64.URLEncoding.EncodeToString(authBytes)
+}
+
+func (r Gitea) RegistryUrl() string {
+	if len(r.Repository) != 0 {
+		if strings.Contains(r.Repository, "/") {
+			return fmt.Sprintf("%s/%s", r.Registry, r.Repository[:strings.LastIndex(r.Repository, "/")])
+		}
+		return fmt.Sprintf("%s/%s", r.Registry, r.Repository)
+	}
+
+	return r.Registry
+}
+
+func (r *Gitea) Create(repository string) error {
+	return nil
+}

--- a/pkg/registry/gitea_test.go
+++ b/pkg/registry/gitea_test.go
@@ -1,0 +1,160 @@
+// MIT License
+//
+// Copyright (c) 2026 buildtool
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package registry
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/apex/log"
+	"github.com/stretchr/testify/assert"
+	mocks "gitlab.com/unboundsoftware/apex-mocks"
+
+	"github.com/buildtool/build-tools/pkg/docker"
+)
+
+func TestGitea_Name(t *testing.T) {
+	registry := &Gitea{Registry: "gitea.example.com", Repository: "org/repo", Username: "user", Token: "token"}
+
+	assert.Equal(t, "Gitea", registry.Name())
+}
+
+func TestGitea_Configured(t *testing.T) {
+	tests := []struct {
+		name       string
+		registry   *Gitea
+		configured bool
+	}{
+		{
+			name:       "configured with repository",
+			registry:   &Gitea{Repository: "org/repo"},
+			configured: true,
+		},
+		{
+			name:       "configured with registry only",
+			registry:   &Gitea{Registry: "gitea.example.com"},
+			configured: true,
+		},
+		{
+			name:       "configured with both",
+			registry:   &Gitea{Registry: "gitea.example.com", Repository: "org/repo"},
+			configured: true,
+		},
+		{
+			name:       "not configured",
+			registry:   &Gitea{},
+			configured: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.configured, tt.registry.Configured())
+		})
+	}
+}
+
+func TestGitea_LoginSuccess(t *testing.T) {
+	client := &docker.MockDocker{}
+	registry := &Gitea{Registry: "gitea.example.com", Repository: "org/repo", Username: "user", Token: "token"}
+	logMock := mocks.New()
+	log.SetHandler(logMock)
+	log.SetLevel(log.DebugLevel)
+	err := registry.Login(client)
+	assert.Nil(t, err)
+	assert.Equal(t, "user", client.Username)
+	assert.Equal(t, "token", client.Password)
+	assert.Equal(t, "gitea.example.com", client.ServerAddress)
+	logMock.Check(t, []string{"debug: Logged in\n"})
+}
+
+func TestGitea_LoginError(t *testing.T) {
+	client := &docker.MockDocker{LoginError: fmt.Errorf("invalid username/password")}
+	registry := &Gitea{}
+	logMock := mocks.New()
+	log.SetHandler(logMock)
+	log.SetLevel(log.DebugLevel)
+	err := registry.Login(client)
+	assert.EqualError(t, err, "invalid username/password")
+	logMock.Check(t, []string{})
+}
+
+func TestGitea_GetAuthInfo(t *testing.T) {
+	registry := &Gitea{Registry: "gitea.example.com", Repository: "org/repo", Username: "user", Token: "token"}
+	auth := registry.GetAuthInfo()
+	assert.Equal(t, "eyJ1c2VybmFtZSI6InVzZXIiLCJwYXNzd29yZCI6InRva2VuIiwic2VydmVyYWRkcmVzcyI6ImdpdGVhLmV4YW1wbGUuY29tIn0=", auth)
+}
+
+func TestGitea_GetAuthConfig(t *testing.T) {
+	registry := &Gitea{Registry: "gitea.example.com", Repository: "org/repo", Username: "user", Token: "token"}
+	auth := registry.GetAuthConfig()
+	assert.Equal(t, "user", auth.Username)
+	assert.Equal(t, "token", auth.Password)
+	assert.Equal(t, "gitea.example.com", auth.ServerAddress)
+}
+
+func TestGitea_Create(t *testing.T) {
+	registry := &Gitea{}
+	err := registry.Create("repo")
+	assert.Nil(t, err)
+}
+
+func TestGitea_RegistryUrl(t *testing.T) {
+	tests := []struct {
+		name        string
+		registry    *Gitea
+		expectedUrl string
+	}{
+		{
+			name:        "with org/repo format",
+			registry:    &Gitea{Registry: "gitea.example.com", Repository: "org/repo"},
+			expectedUrl: "gitea.example.com/org",
+		},
+		{
+			name:        "with user/repo format",
+			registry:    &Gitea{Registry: "gitea.example.com", Repository: "user/myrepo"},
+			expectedUrl: "gitea.example.com/user",
+		},
+		{
+			name:        "with nested path org/subgroup/repo",
+			registry:    &Gitea{Registry: "gitea.example.com", Repository: "org/subgroup/repo"},
+			expectedUrl: "gitea.example.com/org/subgroup",
+		},
+		{
+			name:        "with single name repository",
+			registry:    &Gitea{Registry: "gitea.example.com", Repository: "singlename"},
+			expectedUrl: "gitea.example.com/singlename",
+		},
+		{
+			name:        "with registry only",
+			registry:    &Gitea{Registry: "gitea.example.com"},
+			expectedUrl: "gitea.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expectedUrl, tt.registry.RegistryUrl())
+		})
+	}
+}

--- a/www/docs/config/registry.md
+++ b/www/docs/config/registry.md
@@ -24,6 +24,7 @@ The following registries are supported:
 | [`ecr`](#ecr)             | [AWS Elastic Container Registry](https://docs.aws.amazon.com/ecr/index.html)                                         |
 | [`github`](#github)       | [Github package registry](https://docs.github.com/en/packages/learn-github-packages/introduction-to-github-packages) |
 | [`gitlab`](#gitlab)       | [Gitlab container registry](https://docs.gitlab.com/ee/user/packages/container_registry/)                            |
+| [`gitea`](#gitea)         | [Gitea container registry](https://docs.gitea.com/usage/packages/container)                                          |
 | [`quay`](#quay)           | [Quay docker registry](https://docs.quay.io/)                                                                        |
 | [`gcr`](#gcr)             | [Google Container registry](https://cloud.google.com/container-registry)                                             |
 
@@ -74,6 +75,30 @@ To authenticate `token` or a combination of `username` and `password` must be pr
 | `repository` | The repository part of the docker image name      | `CI_REGISTRY_IMAGE` |
 | `user`       | User to authenticate                              | `CI_REGISTRY_USER`  |
 | `token`      | A personal access token to use for authentication | `CI_JOB_TOKEN`      |
+
+### gitea
+
+Self-hosted [Gitea](https://gitea.com/) instances with container registry support (v1.17+).
+
+Note: Gitea Actions does not yet support automatic token authentication for package registries. You must create a Personal Access Token with `package:write` scope and provide it via the `token` parameter or `GITEA_TOKEN` environment variable.
+
+| Parameter    | Description                                       | Env variable        |
+|:-------------|:--------------------------------------------------|:--------------------|
+| `registry`   | The Gitea server hostname                         | `GITEA_REGISTRY`    |
+| `repository` | The repository path (owner/repo format)           | `GITEA_REPOSITORY`  |
+| `username`   | User to authenticate                              | `GITEA_USERNAME`    |
+| `token`      | A personal access token to use for authentication | `GITEA_TOKEN`       |
+
+Example configuration:
+
+```yaml
+registry:
+  gitea:
+    registry: gitea.example.com
+    username: myuser
+    token: ${GITEA_TOKEN}
+    repository: myorg/myrepo
+```
 
 ### quay
 


### PR DESCRIPTION
Add Gitea as a new container registry provider for self-hosted Gitea
instances with container registry support (v1.17+). Includes:

- New Gitea registry implementation with environment variable support
  (GITEA_REGISTRY, GITEA_USERNAME, GITEA_TOKEN, GITEA_REPOSITORY)
- Configuration integration in pkg/config
- Comprehensive unit tests
- Documentation updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>