### PR TITLE
fix(registry): check Gitea registry before Github

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -227,7 +227,7 @@ func InitEmptyConfig() *Config {
 		},
 	}
 	c.AvailableCI = []ci.CI{c.CI.Azure, c.CI.Buildkite, c.CI.Gitlab, c.CI.TeamCity, c.CI.Github}
-	c.AvailableRegistries = []registry.Registry{c.Registry.Dockerhub, c.Registry.ACR, c.Registry.ECR, c.Registry.Github, c.Registry.Gitlab, c.Registry.Gitea, c.Registry.Quay, c.Registry.GCR}
+	c.AvailableRegistries = []registry.Registry{c.Registry.Dockerhub, c.Registry.ACR, c.Registry.ECR, c.Registry.Gitea, c.Registry.Github, c.Registry.Gitlab, c.Registry.Quay, c.Registry.GCR}
 	return c
 }
 


### PR DESCRIPTION
Move Gitea before Github in AvailableRegistries order so Gitea
gets precedence when both GITEA_* and GITHUB_* environment
variables are present (as in Gitea Actions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>