### PR TITLE
feat: output image digest and name to GITHUB_OUTPUT

### DIFF
--- a/cmd/build/build.go
+++ b/cmd/build/build.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/buildtool/build-tools/pkg/args"
 	"github.com/buildtool/build-tools/pkg/build"
+	"github.com/buildtool/build-tools/pkg/ci"
 	"github.com/buildtool/build-tools/pkg/cli"
 	ver "github.com/buildtool/build-tools/pkg/version"
 )
@@ -65,10 +66,14 @@ func main() {
 		}
 	}
 
-	if err := build.DoBuild(dir, buildArgs); err != nil {
+	digest, err := build.DoBuild(dir, buildArgs)
+	if err != nil {
 		log.Error(err.Error())
 		exitFunc(-1)
 		return
+	}
+	if digest != "" {
+		ci.WriteGitHubOutput("digest", digest)
 	}
 	exitFunc(0)
 }

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -115,7 +115,7 @@ func TestBuild_BrokenConfig(t *testing.T) {
 	client := &docker.MockDocker{}
 	defer func() { _ = os.RemoveAll(name) }()
 	_ = write(name, "Dockerfile", "FROM scratch")
-	err := build(client, name, Args{
+	_, err := build(client, name, Args{
 		Globals:    args.Globals{},
 		Dockerfile: "Dockerfile",
 		BuildArgs:  nil,
@@ -145,7 +145,7 @@ func TestBuild_NoRegistry(t *testing.T) {
 	}
 	defer func() { dockerClient = tmpDockerClient }()
 
-	err := DoBuild(name, Args{Dockerfile: "Dockerfile"})
+	_, err := DoBuild(name, Args{Dockerfile: "Dockerfile"})
 	assert.NoError(t, err)
 	logMock.Check(t, []string{
 		"debug: Using CI <green>Gitlab</green>\n",
@@ -172,7 +172,7 @@ func TestBuild_LoginError(t *testing.T) {
 	client := &docker.MockDocker{LoginError: fmt.Errorf("invalid username/password")}
 	defer func() { _ = os.RemoveAll(name) }()
 	_ = write(name, "Dockerfile", "FROM scratch")
-	err := build(client, name, Args{
+	_, err := build(client, name, Args{
 		Globals:    args.Globals{},
 		Dockerfile: "Dockerfile",
 		BuildArgs:  nil,
@@ -200,7 +200,7 @@ func TestBuild_NoCI(t *testing.T) {
 	client := &docker.MockDocker{BuildError: []error{fmt.Errorf("build error")}}
 
 	_ = write(name, "Dockerfile", "FROM scratch")
-	err := build(client, name, Args{
+	_, err := build(client, name, Args{
 		Globals:    args.Globals{},
 		Dockerfile: "Dockerfile",
 		BuildArgs:  nil,
@@ -231,7 +231,7 @@ func TestBuild_BuildError(t *testing.T) {
 	client := &docker.MockDocker{BuildError: []error{fmt.Errorf("build error")}}
 	defer func() { _ = os.RemoveAll(name) }()
 	_ = write(name, "Dockerfile", "FROM scratch")
-	err := build(client, name, Args{
+	_, err := build(client, name, Args{
 		Globals:    args.Globals{},
 		Dockerfile: "Dockerfile",
 		BuildArgs:  nil,
@@ -264,7 +264,7 @@ func TestBuild_BuildResponseError(t *testing.T) {
 	client := &docker.MockDocker{ResponseError: fmt.Errorf("build error")}
 	defer func() { _ = os.RemoveAll(name) }()
 	_ = write(name, "Dockerfile", "FROM scratch")
-	err := build(client, name, Args{
+	_, err := build(client, name, Args{
 		Globals:    args.Globals{},
 		Dockerfile: "Dockerfile",
 		BuildArgs:  nil,
@@ -297,7 +297,7 @@ func TestBuild_ErrorOutput(t *testing.T) {
 	client := &docker.MockDocker{BrokenOutput: true}
 	defer func() { _ = os.RemoveAll(name) }()
 	_ = write(name, "Dockerfile", "FROM scratch")
-	err := build(client, name, Args{
+	_, err := build(client, name, Args{
 		Globals:    args.Globals{},
 		Dockerfile: "Dockerfile",
 		BuildArgs:  nil,
@@ -332,7 +332,7 @@ func TestBuild_ValidOutput(t *testing.T) {
 	client := &docker.MockDocker{ResponseBody: bufio.NewReader(f)}
 	defer func() { _ = os.RemoveAll(name) }()
 	_ = write(name, "Dockerfile", "FROM scratch")
-	err = build(client, name, Args{
+	_, err = build(client, name, Args{
 		Globals:    args.Globals{},
 		Dockerfile: "Dockerfile",
 		BuildArgs:  nil,
@@ -366,7 +366,7 @@ func TestBuild_BrokenBuildResult(t *testing.T) {
 	client := &docker.MockDocker{ResponseBody: strings.NewReader(`{"id":"moby.image.id","aux":{"id":123}}`)}
 	defer func() { _ = os.RemoveAll(name) }()
 	_ = write(name, "Dockerfile", "FROM scratch")
-	err := build(client, name, Args{
+	_, err := build(client, name, Args{
 		Globals:    args.Globals{},
 		Dockerfile: "Dockerfile",
 		BuildArgs:  nil,
@@ -396,7 +396,7 @@ func TestBuild_WithBuildArgs(t *testing.T) {
 	defer func() { _ = os.RemoveAll(name) }()
 	_ = write(name, "Dockerfile", "FROM scratch")
 
-	err := build(client, name, Args{
+	_, err := build(client, name, Args{
 		Globals:    args.Globals{},
 		Dockerfile: "Dockerfile",
 		BuildArgs:  []string{"buildargs1=1", "buildargs2=2"},
@@ -423,7 +423,7 @@ func TestBuild_WithStrangeBuildArg(t *testing.T) {
 	defer func() { _ = os.RemoveAll(name) }()
 	_ = write(name, "Dockerfile", "FROM scratch")
 
-	err := build(client, name, Args{
+	_, err := build(client, name, Args{
 		Globals:    args.Globals{},
 		Dockerfile: "Dockerfile",
 		BuildArgs:  []string{"buildargs1=1=1", "buildargs2", "buildargs3=", "buildargs4"},
@@ -460,7 +460,7 @@ func TestBuild_WithPlatform(t *testing.T) {
 	defer func() { _ = os.RemoveAll(name) }()
 	_ = write(name, "Dockerfile", "FROM scratch")
 
-	err := build(client, name, Args{
+	_, err := build(client, name, Args{
 		Globals:    args.Globals{},
 		Dockerfile: "Dockerfile",
 		NoLogin:    false,
@@ -560,7 +560,7 @@ func TestBuild_WithSkipLogin(t *testing.T) {
 	_ = write(name, "Dockerfile", "FROM scratch")
 
 	client := &docker.MockDocker{}
-	err := build(client, name, Args{
+	_, err := build(client, name, Args{
 		Globals:    args.Globals{},
 		Dockerfile: "Dockerfile",
 		BuildArgs:  nil,
@@ -593,7 +593,7 @@ func TestBuild_FeatureBranch(t *testing.T) {
 	_ = write(name, "Dockerfile", "FROM scratch")
 
 	client := &docker.MockDocker{}
-	err := build(client, name, Args{
+	_, err := build(client, name, Args{
 		Globals:    args.Globals{},
 		Dockerfile: "Dockerfile",
 		BuildArgs:  nil,
@@ -640,7 +640,7 @@ func TestBuild_MasterBranch(t *testing.T) {
 	defer func() { _ = os.RemoveAll(name) }()
 	_ = write(name, "Dockerfile", "FROM scratch")
 
-	err := build(client, name, Args{
+	_, err := build(client, name, Args{
 		Globals:    args.Globals{},
 		Dockerfile: "Dockerfile",
 		BuildArgs:  nil,
@@ -680,7 +680,7 @@ func TestBuild_MainBranch(t *testing.T) {
 	defer func() { _ = os.RemoveAll(name) }()
 	_ = write(name, "Dockerfile", "FROM scratch")
 
-	err := build(client, name, Args{
+	_, err := build(client, name, Args{
 		Globals:    args.Globals{},
 		Dockerfile: "Dockerfile",
 		BuildArgs:  nil,
@@ -721,7 +721,7 @@ func TestBuild_WithImageName(t *testing.T) {
 	_ = write(name, "Dockerfile", "FROM scratch")
 
 	client := &docker.MockDocker{}
-	err := build(client, name, Args{
+	_, err := build(client, name, Args{
 		Globals:    args.Globals{},
 		Dockerfile: "Dockerfile",
 		BuildArgs:  nil,
@@ -742,8 +742,6 @@ func TestBuild_WithImageName(t *testing.T) {
 		"debug: Logged in\n",
 		"debug: Using build variables commit <green>abc123</green> on branch <green>main</green>\n",
 		"info: Using other as BuildName\n",
-		"info: Using other as BuildName\n",
-		"info: Using other as BuildName\n",
 		"debug: performing docker build with options (auths removed):\ntags:\n    - repo/other:abc123\n    - repo/other:main\n    - repo/other:latest\nsuppressoutput: false\nremotecontext: client-session\nnocache: false\nremove: true\nforceremove: false\npullparent: true\nisolation: \"\"\ncpusetcpus: \"\"\ncpusetmems: \"\"\ncpushares: 0\ncpuquota: 0\ncpuperiod: 0\nmemory: 0\nmemoryswap: -1\ncgroupparent: \"\"\nnetworkmode: \"\"\nshmsize: 268435456\ndockerfile: build-tools-dockerfile\nulimits: []\nbuildargs:\n    BUILDKIT_INLINE_CACHE: \"1\"\n    CI_BRANCH: main\n    CI_COMMIT: abc123\nauthconfigs: {}\ncontext: null\nlabels: {}\nsquash: false\ncachefrom:\n    - repo/other:main\n    - repo/other:latest\nsecurityopt: []\nextrahosts: []\ntarget: \"\"\nsessionid: \"\"\nplatform: \"\"\nversion: \"2\"\nbuildid: \"\"\noutputs: []\n\n",
 		"info: Build successful",
 	})
@@ -754,7 +752,7 @@ func TestBuild_BadDockerHost(t *testing.T) {
 	logMock := mocks.New()
 	log.SetHandler(logMock)
 	log.SetLevel(log.DebugLevel)
-	err := DoBuild(name, Args{})
+	_, err := DoBuild(name, Args{})
 	assert.EqualError(t, err, "unable to parse docker host `abc-123`")
 	logMock.Check(t, []string{})
 }
@@ -776,7 +774,7 @@ func TestBuild_Unreadable_Dockerfile(t *testing.T) {
 	log.SetLevel(log.DebugLevel)
 	client := &docker.MockDocker{}
 
-	err := build(client, name, Args{
+	_, err := build(client, name, Args{
 		Globals:    args.Globals{},
 		Dockerfile: "Dockerfile",
 		BuildArgs:  nil,
@@ -810,7 +808,7 @@ func TestBuild_Empty_Dockerfile(t *testing.T) {
 	log.SetLevel(log.DebugLevel)
 	client := &docker.MockDocker{}
 
-	err := build(client, name, Args{
+	_, err := build(client, name, Args{
 		Globals:    args.Globals{},
 		Dockerfile: "Dockerfile",
 		BuildArgs:  nil,
@@ -844,7 +842,7 @@ func TestBuild_Dockerfile_FromStdin(t *testing.T) {
 	err := os.MkdirAll(name, 0o777)
 	assert.NoError(t, err)
 
-	err = build(client, name, Args{
+	_, err = build(client, name, Args{
 		Globals: args.Globals{
 			StdIn: strings.NewReader("FROM scratch\n"),
 		},
@@ -891,7 +889,7 @@ COPY --from=test file2 .
 	defer func() { _ = os.RemoveAll(name) }()
 	_ = write(name, "Dockerfile", dockerfile)
 
-	err := build(client, name, Args{
+	_, err := build(client, name, Args{
 		Globals:    args.Globals{},
 		Dockerfile: "Dockerfile",
 		BuildArgs:  nil,
@@ -949,7 +947,7 @@ COPY --from=test file2 .
 `
 	defer func() { _ = os.RemoveAll(name) }()
 	_ = write(name, "Dockerfile", dockerfile)
-	err := build(client, name, Args{
+	_, err := build(client, name, Args{
 		Globals:    args.Globals{},
 		Dockerfile: "Dockerfile",
 		BuildArgs:  nil,
@@ -996,7 +994,7 @@ COPY --from=test file2 .
 `
 	defer func() { _ = os.RemoveAll(name) }()
 	_ = write(name, "Dockerfile", dockerfile)
-	err := build(client, name, Args{
+	_, err := build(client, name, Args{
 		Globals:    args.Globals{},
 		Dockerfile: "Dockerfile",
 		BuildArgs:  nil,
@@ -1064,7 +1062,7 @@ COPY --from=test file2 .
 `
 	defer func() { _ = os.RemoveAll(name) }()
 	_ = write(name, "Dockerfile", dockerfile)
-	err := build(client, name, Args{
+	_, err := build(client, name, Args{
 		Globals:    args.Globals{},
 		Dockerfile: "Dockerfile",
 		BuildArgs:  nil,
@@ -1550,7 +1548,11 @@ func Test_buildMultiPlatformWithFactory_Success(t *testing.T) {
 		SolveFunc: func(ctx context.Context, def *llb.Definition, opt client.SolveOpt, statusChan chan *client.SolveStatus) (*client.SolveResponse, error) {
 			capturedOpts = opt
 			close(statusChan)
-			return &client.SolveResponse{}, nil
+			return &client.SolveResponse{
+				ExporterResponse: map[string]string{
+					"containerimage.digest": "sha256:abc123def456",
+				},
+			}, nil
 		},
 	}
 
@@ -1562,7 +1564,7 @@ func Test_buildMultiPlatformWithFactory_Success(t *testing.T) {
 	dir := t.TempDir()
 	_ = write(dir, "Dockerfile", "FROM scratch")
 
-	err := buildMultiPlatformWithFactory(
+	digest, err := buildMultiPlatformWithFactory(
 		&docker.MockDocker{},
 		dir,
 		Args{Platform: "linux/amd64,linux/arm64", Dockerfile: "Dockerfile"},
@@ -1576,6 +1578,7 @@ func Test_buildMultiPlatformWithFactory_Success(t *testing.T) {
 	)
 
 	assert.NoError(t, err)
+	assert.Equal(t, "sha256:abc123def456", digest)
 	assert.Equal(t, "dockerfile.v0", capturedOpts.Frontend)
 	assert.Equal(t, "linux/amd64,linux/arm64", capturedOpts.FrontendAttrs["platform"])
 	assert.Equal(t, "1.0.0", capturedOpts.FrontendAttrs["build-arg:VERSION"])
@@ -1594,7 +1597,7 @@ func Test_buildMultiPlatformWithFactory_ClientConnectionError(t *testing.T) {
 	dir := t.TempDir()
 	_ = write(dir, "Dockerfile", "FROM scratch")
 
-	err := buildMultiPlatformWithFactory(
+	_, err := buildMultiPlatformWithFactory(
 		&docker.MockDocker{},
 		dir,
 		Args{Platform: "linux/amd64,linux/arm64", Dockerfile: "Dockerfile"},
@@ -1629,7 +1632,7 @@ func Test_buildMultiPlatformWithFactory_SolveError(t *testing.T) {
 	dir := t.TempDir()
 	_ = write(dir, "Dockerfile", "FROM scratch")
 
-	err := buildMultiPlatformWithFactory(
+	_, err := buildMultiPlatformWithFactory(
 		&docker.MockDocker{},
 		dir,
 		Args{Platform: "linux/amd64,linux/arm64", Dockerfile: "Dockerfile"},
@@ -1667,7 +1670,7 @@ func Test_buildMultiPlatformWithFactory_ExporterNotFoundError(t *testing.T) {
 	dir := t.TempDir()
 	_ = write(dir, "Dockerfile", "FROM scratch")
 
-	err := buildMultiPlatformWithFactory(
+	_, err := buildMultiPlatformWithFactory(
 		&docker.MockDocker{},
 		dir,
 		Args{Platform: "linux/amd64,linux/arm64", Dockerfile: "Dockerfile"},
@@ -1700,7 +1703,7 @@ func Test_buildMultiPlatformWithFactory_InvalidDirectory(t *testing.T) {
 		return &MockBuildkitClient{}, nil
 	}
 
-	err := buildMultiPlatformWithFactory(
+	_, err := buildMultiPlatformWithFactory(
 		&docker.MockDocker{},
 		"/nonexistent/directory/that/does/not/exist",
 		Args{Platform: "linux/amd64,linux/arm64", Dockerfile: "Dockerfile"},
@@ -1742,7 +1745,7 @@ func Test_buildMultiPlatformWithFactory_ViaDocker(t *testing.T) {
 	dir := t.TempDir()
 	_ = write(dir, "Dockerfile", "FROM scratch")
 
-	err := buildMultiPlatformWithFactory(
+	_, err := buildMultiPlatformWithFactory(
 		&docker.MockDocker{},
 		dir,
 		Args{Platform: "linux/amd64,linux/arm64", Dockerfile: "Dockerfile"},
@@ -1776,7 +1779,7 @@ func Test_buildMultiPlatformWithFactory_ListWorkersError(t *testing.T) {
 	dir := t.TempDir()
 	_ = write(dir, "Dockerfile", "FROM scratch")
 
-	err := buildMultiPlatformWithFactory(
+	_, err := buildMultiPlatformWithFactory(
 		&docker.MockDocker{},
 		dir,
 		Args{Platform: "linux/amd64,linux/arm64", Dockerfile: "Dockerfile"},
@@ -1817,7 +1820,7 @@ func Test_buildMultiPlatformWithFactory_WithECRCache(t *testing.T) {
 		Tag: "my-cache",
 	}
 
-	err := buildMultiPlatformWithFactory(
+	_, err := buildMultiPlatformWithFactory(
 		&docker.MockDocker{},
 		dir,
 		Args{Platform: "linux/amd64,linux/arm64", Dockerfile: "Dockerfile"},
@@ -1871,7 +1874,7 @@ func Test_buildMultiPlatformWithFactory_WithECRCache_DefaultTag(t *testing.T) {
 		Url: "123456789012.dkr.ecr.us-east-1.amazonaws.com/cache",
 	}
 
-	err := buildMultiPlatformWithFactory(
+	_, err := buildMultiPlatformWithFactory(
 		&docker.MockDocker{},
 		dir,
 		Args{Platform: "linux/amd64,linux/arm64", Dockerfile: "Dockerfile"},
@@ -1918,7 +1921,7 @@ func Test_buildMultiPlatformWithFactory_ExportStage(t *testing.T) {
 	dir := t.TempDir()
 	_ = write(dir, "Dockerfile", "FROM scratch AS export-artifacts\nCOPY . /out")
 
-	err := buildMultiPlatformWithFactory(
+	_, err := buildMultiPlatformWithFactory(
 		&docker.MockDocker{},
 		dir,
 		Args{Platform: "linux/amd64", Dockerfile: "Dockerfile"},
@@ -1978,7 +1981,7 @@ func Test_buildMultiPlatformWithFactory_ExportStage_NoAuthWarning(t *testing.T) 
 	_ = write(dir, "Dockerfile", "FROM scratch AS export-files\nCOPY . /out")
 
 	// Call without authenticator - should NOT warn for export stages
-	err := buildMultiPlatformWithFactory(
+	_, err := buildMultiPlatformWithFactory(
 		&docker.MockDocker{},
 		dir,
 		Args{Platform: "linux/amd64", Dockerfile: "Dockerfile"},
@@ -2021,7 +2024,7 @@ func Test_buildMultiPlatformWithFactory_NonExportStage_WarnNoAuth(t *testing.T) 
 	_ = write(dir, "Dockerfile", "FROM scratch")
 
 	// Call without authenticator for non-export stage - should warn
-	err := buildMultiPlatformWithFactory(
+	_, err := buildMultiPlatformWithFactory(
 		&docker.MockDocker{},
 		dir,
 		Args{Platform: "linux/amd64", Dockerfile: "Dockerfile"},

--- a/pkg/ci/github_output_test.go
+++ b/pkg/ci/github_output_test.go
@@ -1,0 +1,85 @@
+// MIT License
+//
+// Copyright (c) 2018 buildtool
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package ci
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWriteGitHubOutput_NotInGitHubActions(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "")
+	tmpFile := t.TempDir() + "/output"
+	_ = os.WriteFile(tmpFile, []byte{}, 0o644)
+	t.Setenv("GITHUB_OUTPUT", tmpFile)
+
+	WriteGitHubOutput("digest", "sha256:abc123")
+
+	content, err := os.ReadFile(tmpFile)
+	assert.NoError(t, err)
+	assert.Empty(t, string(content))
+}
+
+func TestWriteGitHubOutput_NoOutputFile(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "true")
+	t.Setenv("GITHUB_OUTPUT", "")
+
+	// Should not panic
+	WriteGitHubOutput("digest", "sha256:abc123")
+}
+
+func TestWriteGitHubOutput_WritesOutput(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "true")
+	tmpFile := t.TempDir() + "/output"
+	_ = os.WriteFile(tmpFile, []byte{}, 0o644)
+	t.Setenv("GITHUB_OUTPUT", tmpFile)
+
+	WriteGitHubOutput("digest", "sha256:abc123")
+
+	content, err := os.ReadFile(tmpFile)
+	assert.NoError(t, err)
+	assert.Equal(t, "digest=sha256:abc123\n", string(content))
+}
+
+func TestWriteGitHubOutput_AppendsToExistingContent(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "true")
+	tmpFile := t.TempDir() + "/output"
+	_ = os.WriteFile(tmpFile, []byte("existing=value\n"), 0o644)
+	t.Setenv("GITHUB_OUTPUT", tmpFile)
+
+	WriteGitHubOutput("digest", "sha256:abc123")
+
+	content, err := os.ReadFile(tmpFile)
+	assert.NoError(t, err)
+	assert.Equal(t, "existing=value\ndigest=sha256:abc123\n", string(content))
+}
+
+func TestWriteGitHubOutput_InvalidPath(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "true")
+	t.Setenv("GITHUB_OUTPUT", "/nonexistent/path/output")
+
+	// Should not panic
+	WriteGitHubOutput("digest", "sha256:abc123")
+}

--- a/pkg/push/push_test.go
+++ b/pkg/push/push_test.go
@@ -448,7 +448,7 @@ func (m mockRegistry) Create(repository string) error {
 	return errors.New("create error")
 }
 
-func (m mockRegistry) PushImage(client docker.Client, auth, image string) error {
+func (m mockRegistry) PushImage(client docker.Client, auth, image string) (string, error) {
 	panic("implement me")
 }
 

--- a/www/docs/ci/github.md
+++ b/www/docs/ci/github.md
@@ -22,6 +22,52 @@ Read more about available [commands](/commands/build):
 
 > For detailed intructions please follow GitHub Actions [syntax].
 
+## Artifact attestations
+
+Build-tools writes the image name and digest to `$GITHUB_OUTPUT` when running in GitHub Actions. This enables integration with [artifact attestations] for supply chain security.
+
+The following step outputs are available:
+
+| Output       | Description                          | Example                              |
+|:-------------|:-------------------------------------|:-------------------------------------|
+| `image-name` | Full image name without tag          | `ghcr.io/org/my-image`               |
+| `digest`     | Image digest                         | `sha256:af534ee896ce2ac80f...`        |
+
+- **With `BUILDKIT_HOST`**: The `build` step outputs both values (images are pushed during build)
+- **Without `BUILDKIT_HOST`**: The `build` step outputs `image-name`, the `push` step outputs both
+
+```yaml
+name: Build and Attest
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: buildtool/setup-buildtools-action@v1
+
+      - name: Build
+        id: build
+        run: build
+
+      - name: Push
+        id: push
+        run: push
+
+      - name: Attest
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ steps.push.outputs.image-name || steps.build.outputs.image-name }}
+          subject-digest: ${{ steps.push.outputs.digest || steps.build.outputs.digest }}
+```
+
 [Github Actions]: https://github.com/features/actions
 [setup-buildtools-action]: https://github.com/buildtool/setup-buildtools-action
 [syntax]: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#About-yaml-syntax-for-workflows
+[artifact attestations]: https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds

--- a/www/docs/commands/build.md
+++ b/www/docs/commands/build.md
@@ -242,3 +242,16 @@ build --platform linux/amd64,linux/arm64
 
 !!! tip "Separate cache repository"
     It's recommended to use a dedicated ECR repository for cache storage, separate from your image repositories. This allows you to apply different lifecycle policies and keeps your cache isolated.
+
+## GitHub Actions outputs
+
+When running in GitHub Actions, the `build` command writes the following step outputs to `$GITHUB_OUTPUT`:
+
+| Output       | Description                          | When available                        |
+|:-------------|:-------------------------------------|:--------------------------------------|
+| `image-name` | Full image name without tag          | Always                                |
+| `digest`     | Image digest (`sha256:...`)          | Only when `BUILDKIT_HOST` is set      |
+
+When `BUILDKIT_HOST` is not set, the digest is instead output by the [`push`](push.md) command.
+
+See [GitHub Actions](../ci/github.md#artifact-attestations) for a full workflow example with artifact attestations.

--- a/www/docs/commands/push.md
+++ b/www/docs/commands/push.md
@@ -11,3 +11,19 @@ By following the conventions no additional flags are needed, but the following f
 ```sh
 $ push --file docker/Dockerfile.build
 ```
+
+## GitHub Actions outputs
+
+When running in GitHub Actions, the `push` command writes the following step outputs to `$GITHUB_OUTPUT`:
+
+| Output       | Description                          |
+|:-------------|:-------------------------------------|
+| `image-name` | Full image name without tag          |
+| `digest`     | Image digest (`sha256:...`)          |
+
+This enables integration with artifact attestations for supply chain security.
+
+!!! note
+    When `BUILDKIT_HOST` is set, images are pushed during [`build`](build.md) and `push` becomes a no-op. In that case, the outputs come from the `build` step instead.
+
+See [GitHub Actions](../ci/github.md#artifact-attestations) for a full workflow example.


### PR DESCRIPTION
## Summary
- Capture image digest (`sha256:...`) from buildkit `SolveResponse` and Docker push response
- Write `image-name` and `digest` as step outputs to `$GITHUB_OUTPUT` when running in GitHub Actions
- Enables `actions/attest-build-provenance` workflows without hardcoding the image name

## How it works
- **Buildkit path** (`BUILDKIT_HOST` set): `build` outputs both `image-name` and `digest`
- **Docker API path**: `build` outputs `image-name`, `push` outputs both `image-name` and `digest`
- Outputs are only written when `GITHUB_ACTIONS=true`

## Usage
```yaml
- name: Build
  id: build
  run: build
- name: Push
  id: push
  run: push
- name: Attest
  uses: actions/attest-build-provenance@v2
  with:
    subject-name: ${{ steps.push.outputs.image-name || steps.build.outputs.image-name }}
    subject-digest: ${{ steps.push.outputs.digest || steps.build.outputs.digest }}
```

## Changes
- New `pkg/ci/github_output.go` — `WriteGitHubOutput()` helper
- `pkg/build/build.go` — Return digest from build functions, write `image-name`
- `pkg/registry/registry.go` — `PushImage()` returns `(string, error)` with digest
- `pkg/push/push.go` — Capture digest and write outputs
- `cmd/build/build.go` — Write digest output
- Updated docs: `www/docs/ci/github.md`, `www/docs/commands/build.md`, `www/docs/commands/push.md`
- Tests for all changes

## Test plan
- [x] All existing tests pass
- [x] New tests for `WriteGitHubOutput` (5 cases)
- [x] New tests for `PushImage` digest capture (2 cases)
- [x] `buildMultiPlatformWithFactory` test verifies digest from `SolveResponse`
- [x] Pre-commit hooks pass (linting, formatting, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)