### PR TITLE
fix(deps): update Go to 1.25.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildtool/build-tools
 
-go 1.25.6
+go 1.25.7
 
 require (
 	dario.cat/mergo v1.0.2


### PR DESCRIPTION
## Summary
- Bump Go from 1.25.6 to 1.25.7 to fix go-vuln security findings
- Go 1.25.7 includes security fixes for `crypto/tls` and `crypto/x509`

## Test plan
- [x] `go mod tidy` clean
- [x] All tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)