### PR TITLE
fix(registry): parse digest from status field as fallback for ECR

### DIFF
--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -27,6 +27,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"regexp"
 
 	"github.com/apex/log"
 	img "github.com/docker/docker/api/types/image"
@@ -34,6 +35,8 @@ import (
 
 	"github.com/buildtool/build-tools/pkg/docker"
 )
+
+var digestRegexp = regexp.MustCompile(`sha256:[a-fA-F0-9]{64}`)
 
 type Registry interface {
 	Configured() bool
@@ -86,6 +89,10 @@ func (dockerRegistry) PushImage(client docker.Client, auth, image string) (strin
 		}
 		if r.Aux != nil && r.Aux.Digest != "" {
 			digestResult = r.Aux.Digest
+		} else if digestResult == "" && r.Status != "" {
+			if match := digestRegexp.FindString(r.Status); match != "" {
+				digestResult = match
+			}
 		}
 	}
 	return digestResult, nil


### PR DESCRIPTION
## Summary

- ECR's Docker push response doesn't include the digest in the `aux` field that `PushImage` was relying on
- Added fallback: parse `sha256:<hex>` from the `Status` field when `Aux.Digest` is empty
- `Aux.Digest` still takes precedence when present (Docker Hub, GHCR, GitLab)
- Added tests for ECR-style status digest and aux-takes-precedence behavior

## Context

The `GITHUB_OUTPUT` support added in v0.4.8 (#1378) works correctly for registries that return `aux.Digest` (Docker Hub, GHCR, GitLab). However, ECR returns the digest in a status message like `"v1: digest: sha256:... size: 1234"` instead. This caused empty `digest` output on ECR pushes, breaking `actions/attest-build-provenance` workflows.