### PR TITLE
fix(ci): use squash merge in automerge workflow

### DIFF
--- a/.github/workflows/automerge_pr.yaml
+++ b/.github/workflows/automerge_pr.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Enable auto-merge for PRs
-        run: gh pr merge --auto --merge --delete-branch "$PR_URL"
+        run: gh pr merge --auto --squash --delete-branch "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GH_TOKEN: ${{secrets.PR_GITHUB_TOKEN}}


### PR DESCRIPTION
## Summary
- The automerge workflow used `--merge` but the branch ruleset only allows `squash` and `rebase`
- This mismatch prevented auto-merge from executing on approved PRs (e.g. #1405)
- Changed to `--squash` to match the branch rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)