### PR TITLE
feat: inject Go cache mounts into Dockerfile builds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ The configuration file defines:
 - `vcs`: Version control settings
 - `ci`: CI platform credentials (azure, buildkite, gitlab, github, teamcity)
 - `registry`: Registry credentials (dockerhub, acr, ecr, gcr, github, gitlab, gitea, quay)
-- `cache`: Layer cache configuration (ecr)
+- `cache`: Layer cache configuration (ecr, go_mounts)
 - `targets`: Kubernetes deployment targets (context, namespace, kubeconfig)
 - `git`: Git user configuration for commits (used by promote command)
 - `gitops`: GitOps repository configurations (url, path)
@@ -161,6 +161,31 @@ The build system supports using AWS ECR as a remote layer cache for buildkit bui
 **Key Code Locations**:
 - Config structs: `pkg/config/config.go` (`CacheConfig`, `ECRCache`)
 - Cache import/export: `pkg/build/build.go` (`buildCacheImports()`, `buildCacheExports()`)
+- Tests: `pkg/build/build_test.go`, `pkg/config/config_test.go`
+
+## Go Build Cache Mounts
+
+The build system supports automatic injection of BuildKit `--mount=type=cache` directives for Go build and module caches into Dockerfile `RUN` instructions:
+
+**Configuration**:
+- Set via `.buildtools.yaml`:
+  ```yaml
+  cache:
+    go_mounts: true
+  ```
+- Or via environment variable: `BUILDTOOLS_CACHE_GO_MOUNTS=true`
+
+**Implementation Details**:
+- `injectGoCacheMounts()` preprocesses Dockerfile content before writing the temp file
+- Identifies golang stages (including inherited ones via alias tracking in `parseGoStage()`)
+- Injects `--mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod` into shell-form `RUN` instructions
+- Skips exec-form `RUN`, non-golang stages, and instructions that already have Go cache mounts
+- Modifies the temp copy only, not the original Dockerfile
+
+**Key Code Locations**:
+- Config field: `pkg/config/config.go` (`CacheConfig.GoMounts`)
+- Injection logic: `pkg/build/build.go` (`injectGoCacheMounts()`, `parseGoStage()`, `isShellRunInstruction()`, `hasGoCacheMount()`)
+- Integration point: `pkg/build/build.go` `build()` function, between Dockerfile read and temp file write
 - Tests: `pkg/build/build_test.go`, `pkg/config/config_test.go`
 
 ## GitHub Actions Outputs (Image Digest & Name)

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -203,6 +203,10 @@ func build(client docker.Client, dir string, buildVars Args) (string, error) {
 		log.Error(fmt.Sprintf("<red>%s</red>", err.Error()))
 		return "", err
 	}
+	if cfg.Cache.GoMounts {
+		content = injectGoCacheMounts(content)
+		log.Debugf("Injected Go cache mounts into Dockerfile\n")
+	}
 	dockerFile, err := os.Create(filepath.Join(dir, "build-tools-dockerfile"))
 	if err != nil {
 		return "", err
@@ -775,4 +779,80 @@ func (t *tracer) write(msg jsonmessage.JSONMessage) {
 	}
 
 	t.displayCh <- &s
+}
+
+// goCacheMountPrefix is injected before the command in RUN instructions within
+// golang stages to persist Go build and module caches across builds via BuildKit.
+var goCacheMountPrefix = []byte(
+	"--mount=type=cache,target=/root/.cache/go-build " +
+		"--mount=type=cache,target=/go/pkg/mod ")
+
+// injectGoCacheMounts preprocesses Dockerfile content to add BuildKit cache
+// mount directives for Go build and module caches into RUN instructions within
+// golang-based stages. It modifies a copy of the content, not the original file.
+func injectGoCacheMounts(content []byte) []byte {
+	lines := bytes.Split(content, []byte("\n"))
+	goStages := make(map[string]bool)
+	inGoStage := false
+
+	for i, line := range lines {
+		trimmed := bytes.TrimSpace(line)
+		upper := bytes.ToUpper(trimmed)
+
+		// Track FROM instructions to identify golang stages
+		if bytes.HasPrefix(upper, []byte("FROM ")) {
+			inGoStage = parseGoStage(string(trimmed), goStages)
+			continue
+		}
+
+		// Inject cache mounts into shell-form RUN instructions in Go stages
+		if inGoStage && isShellRunInstruction(trimmed) && !hasGoCacheMount(trimmed) {
+			idx := bytes.Index(bytes.ToUpper(line), []byte("RUN "))
+			if idx >= 0 {
+				newLine := make([]byte, 0, len(line)+len(goCacheMountPrefix))
+				newLine = append(newLine, line[:idx+4]...)
+				newLine = append(newLine, goCacheMountPrefix...)
+				newLine = append(newLine, line[idx+4:]...)
+				lines[i] = newLine
+			}
+		}
+	}
+	return bytes.Join(lines, []byte("\n"))
+}
+
+// parseGoStage checks if a FROM line uses a golang base image (directly or via
+// a previously identified Go stage alias). Tracks stage names in goStages map.
+// Returns true if the current stage is a Go stage.
+func parseGoStage(fromLine string, goStages map[string]bool) bool {
+	fields := strings.Fields(fromLine)
+	if len(fields) < 2 {
+		return false
+	}
+	image := strings.ToLower(fields[1])
+
+	isGo := strings.HasPrefix(image, "golang") || goStages[image]
+
+	// Register named stage (FROM image AS name)
+	if len(fields) >= 4 && strings.EqualFold(fields[2], "AS") {
+		if isGo {
+			goStages[strings.ToLower(fields[3])] = true
+		}
+	}
+	return isGo
+}
+
+// isShellRunInstruction returns true if the trimmed line is a shell-form RUN
+// instruction (not exec form like RUN ["cmd", ...]).
+func isShellRunInstruction(trimmed []byte) bool {
+	if !bytes.HasPrefix(bytes.ToUpper(trimmed), []byte("RUN ")) {
+		return false
+	}
+	afterRun := bytes.TrimSpace(trimmed[4:])
+	// Skip exec form: RUN ["cmd", ...]
+	return len(afterRun) == 0 || afterRun[0] != '['
+}
+
+// hasGoCacheMount checks if a line already contains a Go build cache mount.
+func hasGoCacheMount(line []byte) bool {
+	return bytes.Contains(line, []byte("--mount=type=cache,target=/root/.cache/go-build"))
 }

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -2100,3 +2100,214 @@ func Test_extractHost(t *testing.T) {
 		})
 	}
 }
+
+func Test_injectGoCacheMounts(t *testing.T) {
+	mount := "--mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod "
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "simple golang stage",
+			input:    "FROM golang:1.24 AS builder\nRUN go build -o /app",
+			expected: "FROM golang:1.24 AS builder\nRUN " + mount + "go build -o /app",
+		},
+		{
+			name:     "non-golang stage unchanged",
+			input:    "FROM alpine\nRUN apk add go",
+			expected: "FROM alpine\nRUN apk add go",
+		},
+		{
+			name:     "stage inheritance",
+			input:    "FROM golang:1.24 AS deps\nRUN go mod download\nFROM deps AS builder\nRUN go build",
+			expected: "FROM golang:1.24 AS deps\nRUN " + mount + "go mod download\nFROM deps AS builder\nRUN " + mount + "go build",
+		},
+		{
+			name:     "already has mounts",
+			input:    "FROM golang:1.24 AS builder\nRUN --mount=type=cache,target=/root/.cache/go-build go build",
+			expected: "FROM golang:1.24 AS builder\nRUN --mount=type=cache,target=/root/.cache/go-build go build",
+		},
+		{
+			name:     "exec form RUN unchanged",
+			input:    "FROM golang:1.24 AS builder\nRUN [\"go\", \"build\"]",
+			expected: "FROM golang:1.24 AS builder\nRUN [\"go\", \"build\"]",
+		},
+		{
+			name:     "mixed stages only modifies golang",
+			input:    "FROM golang:1.24 AS builder\nRUN go build\nFROM alpine AS runtime\nRUN echo done",
+			expected: "FROM golang:1.24 AS builder\nRUN " + mount + "go build\nFROM alpine AS runtime\nRUN echo done",
+		},
+		{
+			name:     "existing mount flags get cache prepended",
+			input:    "FROM golang:1.24 AS builder\nRUN --mount=type=secret,id=x go build",
+			expected: "FROM golang:1.24 AS builder\nRUN " + mount + "--mount=type=secret,id=x go build",
+		},
+		{
+			name:     "no FROM instruction",
+			input:    "RUN go build",
+			expected: "RUN go build",
+		},
+		{
+			name:     "empty content",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "golang alpine variant",
+			input:    "FROM golang:1.24-alpine AS builder\nRUN go build",
+			expected: "FROM golang:1.24-alpine AS builder\nRUN " + mount + "go build",
+		},
+		{
+			name:     "multiple RUN in golang stage",
+			input:    "FROM golang:1.24 AS builder\nRUN go mod download\nRUN go build -o /app",
+			expected: "FROM golang:1.24 AS builder\nRUN " + mount + "go mod download\nRUN " + mount + "go build -o /app",
+		},
+		{
+			name:     "indented RUN",
+			input:    "FROM golang:1.24 AS builder\n  RUN go build",
+			expected: "FROM golang:1.24 AS builder\n  RUN " + mount + "go build",
+		},
+		{
+			name:     "case insensitive FROM and RUN",
+			input:    "from golang:1.24 as builder\nrun go build",
+			expected: "from golang:1.24 as builder\nrun " + mount + "go build",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := injectGoCacheMounts([]byte(tt.input))
+			assert.Equal(t, tt.expected, string(got))
+		})
+	}
+}
+
+func Test_parseGoStage(t *testing.T) {
+	tests := []struct {
+		name     string
+		fromLine string
+		existing map[string]bool
+		wantGo   bool
+		wantMap  map[string]bool
+	}{
+		{
+			name:     "golang image",
+			fromLine: "FROM golang:1.24 AS builder",
+			existing: map[string]bool{},
+			wantGo:   true,
+			wantMap:  map[string]bool{"builder": true},
+		},
+		{
+			name:     "alpine image",
+			fromLine: "FROM alpine:3.19",
+			existing: map[string]bool{},
+			wantGo:   false,
+			wantMap:  map[string]bool{},
+		},
+		{
+			name:     "inherited stage",
+			fromLine: "FROM deps AS builder",
+			existing: map[string]bool{"deps": true},
+			wantGo:   true,
+			wantMap:  map[string]bool{"deps": true, "builder": true},
+		},
+		{
+			name:     "unknown stage not go",
+			fromLine: "FROM mybase AS builder",
+			existing: map[string]bool{},
+			wantGo:   false,
+			wantMap:  map[string]bool{},
+		},
+		{
+			name:     "no AS clause",
+			fromLine: "FROM golang:1.24",
+			existing: map[string]bool{},
+			wantGo:   true,
+			wantMap:  map[string]bool{},
+		},
+		{
+			name:     "empty FROM",
+			fromLine: "FROM",
+			existing: map[string]bool{},
+			wantGo:   false,
+			wantMap:  map[string]bool{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseGoStage(tt.fromLine, tt.existing)
+			assert.Equal(t, tt.wantGo, got)
+			assert.Equal(t, tt.wantMap, tt.existing)
+		})
+	}
+}
+
+func Test_isShellRunInstruction(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want bool
+	}{
+		{
+			name: "shell form",
+			line: "RUN go build",
+			want: true,
+		},
+		{
+			name: "exec form",
+			line: "RUN [\"go\", \"build\"]",
+			want: false,
+		},
+		{
+			name: "not RUN",
+			line: "COPY . .",
+			want: false,
+		},
+		{
+			name: "run with mount",
+			line: "RUN --mount=type=secret,id=x go build",
+			want: true,
+		},
+		{
+			name: "lowercase run",
+			line: "run go build",
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isShellRunInstruction([]byte(tt.line))
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_hasGoCacheMount(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want bool
+	}{
+		{
+			name: "has mount",
+			line: "RUN --mount=type=cache,target=/root/.cache/go-build go build",
+			want: true,
+		},
+		{
+			name: "no mount",
+			line: "RUN go build",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hasGoCacheMount([]byte(tt.line))
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -100,6 +100,9 @@ type Gitops struct {
 type CacheConfig struct {
 	// ECR configures AWS ECR as a layer cache backend for buildkit builds.
 	ECR *ECRCache `yaml:"ecr"`
+	// GoMounts enables automatic injection of --mount=type=cache directives for
+	// Go build and module caches into RUN instructions within golang Dockerfile stages.
+	GoMounts bool `yaml:"go_mounts" env:"BUILDTOOLS_CACHE_GO_MOUNTS"`
 }
 
 // ECRCache configures ECR-based layer caching for buildkit builds.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -688,3 +688,30 @@ func TestLoad_YAML_Gitea_Env(t *testing.T) {
 	assert.Equal(t, "token", cfg.Registry.Gitea.Token)
 	assert.Equal(t, "org/repo", cfg.Registry.Gitea.Repository)
 }
+
+func TestCacheConfig_GoMounts_YAML(t *testing.T) {
+	yaml := `
+cache:
+  go_mounts: true
+`
+	name := filepath.Join(t.TempDir(), ".buildtools.yaml")
+	_ = os.WriteFile(name, []byte(yaml), 0o644)
+
+	cfg, err := Load(filepath.Dir(name))
+	assert.NoError(t, err)
+	assert.True(t, cfg.Cache.GoMounts)
+}
+
+func TestCacheConfig_GoMounts_Env(t *testing.T) {
+	t.Setenv("BUILDTOOLS_CACHE_GO_MOUNTS", "true")
+
+	cfg, err := Load(t.TempDir())
+	assert.NoError(t, err)
+	assert.True(t, cfg.Cache.GoMounts)
+}
+
+func TestCacheConfig_GoMounts_Default(t *testing.T) {
+	cfg, err := Load(t.TempDir())
+	assert.NoError(t, err)
+	assert.False(t, cfg.Cache.GoMounts)
+}

--- a/www/docs/commands/build.md
+++ b/www/docs/commands/build.md
@@ -243,6 +243,54 @@ build --platform linux/amd64,linux/arm64
 !!! tip "Separate cache repository"
     It's recommended to use a dedicated ECR repository for cache storage, separate from your image repositories. This allows you to apply different lifecycle policies and keeps your cache isolated.
 
+## Go build cache mounts
+
+When building Go applications, you can enable automatic injection of BuildKit cache mount directives into your Dockerfile. This persists Go's internal build cache and module cache between builds, so only changed packages get recompiled — even when the Docker layer cache is busted by a source file change.
+
+### Configuration
+
+Add the following to your `.buildtools.yaml`:
+
+```yaml
+cache:
+  go_mounts: true
+```
+
+Or use an environment variable:
+
+```shell
+export BUILDTOOLS_CACHE_GO_MOUNTS=true
+```
+
+### How it works
+
+When enabled, build-tools automatically injects `--mount=type=cache` directives into every shell-form `RUN` instruction within golang-based Dockerfile stages:
+
+```dockerfile
+# Your Dockerfile (unchanged)
+FROM golang:1.24 AS builder
+RUN go build -o /app
+
+# What buildkit actually sees
+FROM golang:1.24 AS builder
+RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod go build -o /app
+```
+
+The injection:
+
+- Only applies to stages using a `golang` base image (including inherited stages like `FROM deps AS builder` where `deps` is a golang stage)
+- Skips exec-form `RUN` instructions (`RUN ["go", "build"]`)
+- Skips instructions that already have Go cache mounts
+- Modifies a temporary copy of the Dockerfile, not the original
+
+### Requirements
+
+- `BUILDKIT_HOST` must be set (cache mounts require buildkit)
+- BuildKit must have persistent storage (PVC) for the cache to survive between builds
+
+!!! tip "Combine with ECR layer cache"
+    Go cache mounts and [ECR layer cache](#layer-caching-with-ecr) complement each other. ECR caches entire Docker layers across build instances, while Go cache mounts provide package-level granularity within a single buildkit instance. When a source file change busts the ECR layer cache, the Go build cache still avoids recompiling unchanged packages.
+
 ## GitHub Actions outputs
 
 When running in GitHub Actions, the `build` command writes the following step outputs to `$GITHUB_OUTPUT`:

--- a/www/docs/config/config.md
+++ b/www/docs/config/config.md
@@ -7,6 +7,7 @@ and a list of [`targets`](targets.md) to use.
 |      Key             |                   Description       |
 | :------------------- | :---------------------------------- |
 | registry  | [registry](registry.md) registry to push to    |
+| cache     | [cache](../commands/build.md#layer-caching-with-ecr) configuration (ECR layer cache, Go build cache mounts) |
 | targets   | [targets](targets.md) to deploy to             |
 | git       |  [git](git.md) configuration block             |
 | gitops    |  [git repos](gitops.md) to push descriptors to |


### PR DESCRIPTION
## Summary
- Add `GoMounts` bool field to `CacheConfig` (configurable via `BUILDTOOLS_CACHE_GO_MOUNTS` env var or `cache.go_mounts` in YAML)
- Implement `injectGoCacheMounts()` that preprocesses Dockerfile content to add `--mount=type=cache` directives for `/root/.cache/go-build` and `/go/pkg/mod` into `RUN` instructions within golang stages
- Handles stage inheritance (`FROM deps AS builder` where `deps` is a golang stage), exec form skipping, existing mount detection, and case-insensitive instructions
- 25 new test cases across 4 test functions

## How it works
When enabled, build-tools injects `--mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod` into every shell-form `RUN` instruction within golang-based Dockerfile stages. This is done on the temp copy of the Dockerfile, not the original. BuildKit then persists Go's internal build cache on its PVC between builds, so only changed packages get recompiled.

## Test plan
- [x] `go test ./pkg/config/... ./pkg/build/...` — all tests pass
- [x] `go vet ./...` — no issues
- [ ] Manual test: set `BUILDTOOLS_CACHE_GO_MOUNTS=true`, run `build-tools build --verbose`, verify temp Dockerfile contains cache mounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)