### PR TITLE
fix(deps): bump Go to 1.26.1 to fix stdlib vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildtool/build-tools
 
-go 1.25.7
+go 1.26.1
 
 require (
 	dario.cat/mergo v1.0.2


### PR DESCRIPTION
## Summary
- Bumps Go version in go.mod from 1.25.7 to 1.26.1
- Fixes 5 stdlib vulnerabilities: GO-2026-4603 (html/template), GO-2026-4602 (os), GO-2026-4601 (net/url), GO-2026-4600 (crypto/x509), GO-2026-4599
- These were causing the golang-vulnerabilities CI check to fail (e.g. PR #1420)

## Test plan
- [x] `govulncheck ./...` reports no vulnerabilities
- [x] All tests pass
- [x] Pre-commit hooks pass