### PR TITLE
style: apply gofumpt v0.10 formatting

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -475,7 +475,8 @@ func buildMultiPlatformWithFactory(dkrClient docker.Client, dir string, buildVar
 			return dkrClient.DialHijack(ctx, "/session", proto, meta)
 		}
 
-		bkClient, err = clientFactory(ctx, "",
+		bkClient, err = clientFactory(
+			ctx, "",
 			client.WithContextDialer(dialContext),
 			client.WithSessionDialer(dialSession),
 		)
@@ -804,7 +805,8 @@ func (t *tracer) write(msg jsonstream.Message) {
 // golang stages to persist Go build and module caches across builds via BuildKit.
 var goCacheMountPrefix = []byte(
 	"--mount=type=cache,target=/root/.cache/go-build " +
-		"--mount=type=cache,target=/go/pkg/mod ")
+		"--mount=type=cache,target=/go/pkg/mod ",
+)
 
 // injectGoCacheMounts preprocesses Dockerfile content to add BuildKit cache
 // mount directives for Go build and module caches into RUN instructions within

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -108,5 +108,6 @@ func DefaultClient() (Client, error) {
 	return mobyclient.New(
 		mobyclient.WithTLSClientConfigFromEnv(),
 		mobyclient.WithHostFromEnv(),
-		mobyclient.WithAPIVersionFromEnv())
+		mobyclient.WithAPIVersionFromEnv(),
+	)
 }

--- a/pkg/kubecmd/kubecmd_test.go
+++ b/pkg/kubecmd/kubecmd_test.go
@@ -85,7 +85,8 @@ func TestKubecmd_MissingTarget(t *testing.T) {
 	assert.Nil(t, cmd)
 	logMock.Check(t, []string{
 		fmt.Sprintf(
-			"debug: Parsing config from file: <green>'%s'</green>\n", filePath),
+			"debug: Parsing config from file: <green>'%s'</green>\n", filePath,
+		),
 		"warn: no target matching dummy found\n",
 	})
 }

--- a/pkg/push/push.go
+++ b/pkg/push/push.go
@@ -106,7 +106,8 @@ func doPush(client docker.Client, cfg *config.Config, dir, dockerfile string) in
 		log.Error("Commit and/or branch information is <red>missing</red>. Perhaps your not in a Git repository or forgot to set environment variables?")
 		return -6
 	}
-	tags = append(tags,
+	tags = append(
+		tags,
 		docker.Tag(currentRegistry.RegistryUrl(), currentCI.BuildName(), currentCI.Commit()),
 		docker.Tag(currentRegistry.RegistryUrl(), currentCI.BuildName(), currentCI.BranchReplaceSlash()),
 	)


### PR DESCRIPTION
Latest gofumpt (v0.10.0) wraps trailing closing parens onto their own
line for multi-line function calls and slice literals. No behavior
changes — formatting only.

Affected files:
- pkg/build/build.go
- pkg/docker/docker.go
- pkg/kubecmd/kubecmd_test.go
- pkg/push/push.go