### PR TITLE
chore(renovate): enable OSV vulnerability alerts

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,10 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>buildtool/renovate-config"
-  ]
+  ],
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["security"]
+  }
 }


### PR DESCRIPTION
## What
Enable `osvVulnerabilityAlerts` (plus explicit `vulnerabilityAlerts`) in renovate.json.

## Why
govulncheck flagged vulns in `golang.org/x/net` (indirect) and `golang.org/x/crypto` (direct). Renovate's gomod manager skips `// indirect` deps by default, so it never proposed the x/net fix — the direct x/crypto bump landed via #1497 but the indirect x/net vuln stayed open.

`osvVulnerabilityAlerts` makes Renovate query the OSV database (same source as govulncheck) and raise security PRs for vulnerable deps, **including indirect modules**.

## Verified
Local dry-run (`renovate --platform=local --dry-run=full`) detected and set remediation targets matching govulncheck:
- `golang.org/x/crypto` → >= 0.52.0
- `golang.org/x/net` (indirect) → >= 0.55.0

Security PRs will carry the `security` label.

Follow-up: promote the same setting to the shared `buildtool/renovate-config` preset to cover all org repos.