### PR TITLE
fix(security): bump go to 1.26.4 to patch stdlib vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildtool/build-tools
 
-go 1.26.3
+go 1.26.4
 
 require (
 	dario.cat/mergo v1.0.2


### PR DESCRIPTION
## Problem

Several open PRs fail CI in the `golang-vulnerabilities` (govulncheck) job. The failure is **not** caused by any of the updated dependencies — every PR fails identically because the vulnerabilities are in the **Go standard library**.

govulncheck (`opzkit/govulncheck-action`, `go-version-file: go.mod`) installs the Go toolchain from the go.mod `go` directive, which is pinned to **1.26.3**. That toolchain is flagged for stdlib vulnerabilities:

- `crypto/x509` — `Certificate.Verify` / `Certificate.VerifyHostname` / `HostnameError.Error`
- `net/textproto` / `mime` — `Reader.ReadMIMEHeader` / `WordDecoder.DecodeHeader`

Both are fixed in **go1.26.4**. The earlier `golang` Docker tag bump to 1.26.4 did not fix CI because it never touched the go.mod directive that setup-go reads.

## Fix

Bump the go.mod `go` directive 1.26.3 → 1.26.4 so setup-go installs the patched toolchain. `govulncheck ./...` then reports **No vulnerabilities found**.

## Verification

- `go build ./...` — ok
- `govulncheck ./...` — No vulnerabilities found
- `pre-commit run --all-files` — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)