### PR TITLE
ci(renovate): enable go directive updates to fix govuln failures

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,13 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>buildtool/renovate-config"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["gomod"],
+      "matchDepNames": ["go"],
+      "matchDepTypes": ["golang"],
+      "rangeStrategy": "bump"
+    }
   ]
 }


### PR DESCRIPTION
## Problem
PRs fail the `golang-vulnerabilities` (govulncheck) CI job on stdlib vulnerabilities. govulncheck installs the toolchain from the go.mod `go` directive via setup-go, so an unpatched patch release there fails every PR regardless of which dependency it touches.

## Cause
Renovate disables `go` directive updates by default ("Renovate's default behavior is not to propose upgrades to it"). It bumped the golang Docker tag to 1.26.5 but left `go 1.26.4` in go.mod.

## Fix
Add a packageRule with `rangeStrategy: bump` matching the `go` directive (depName `go`, depType `golang`) so Renovate opens PRs bumping it to the latest release. The shared preset's existing gomod minor/patch automerge + gomodTidy make it hands-off.

Follow-up: move this rule into the shared `buildtool/renovate-config` preset to cover all repos.