### PR TITLE
fix(ci): derive the image name from GITHUB_REPOSITORY

### DIFF
--- a/pkg/ci/github.go
+++ b/pkg/ci/github.go
@@ -23,6 +23,7 @@
 package ci
 
 import (
+	"path"
 	"path/filepath"
 	"strings"
 )
@@ -31,6 +32,7 @@ type Github struct {
 	*Common
 	CICommit     string `env:"GITHUB_SHA"`
 	CIBuildName  string `env:"RUNNER_WORKSPACE"`
+	CIRepository string `env:"GITHUB_REPOSITORY"`
 	CIBranchName string `env:"GITHUB_REF"`
 }
 
@@ -45,11 +47,18 @@ func (c *Github) BranchReplaceSlash() string {
 }
 
 func (c *Github) BuildName() string {
+	// GITHUB_REPOSITORY is "<owner>/<repository>" and names the repository directly.
+	// Prefer it over deriving the name from RUNNER_WORKSPACE, whose layout differs per
+	// platform: GitHub Actions uses /home/runner/work/<repository>, while Gitea Actions
+	// uses /workspace/<owner>/<repository> and exports its parent, so the last path
+	// element there is the owner rather than the repository.
+	if c.CIRepository != "" {
+		return c.Common.BuildName(path.Base(c.CIRepository))
+	}
 	if c.CIBuildName != "" {
 		return c.Common.BuildName(filepath.Base(c.CIBuildName))
-	} else {
-		return c.Common.BuildName(c.CIBuildName)
 	}
+	return c.Common.BuildName(c.CIBuildName)
 }
 
 func (c *Github) Branch() string {

--- a/pkg/ci/github_test.go
+++ b/pkg/ci/github_test.go
@@ -43,8 +43,22 @@ func TestGithub_BuildName(t *testing.T) {
 	assert.Equal(t, "name", ci.BuildName())
 }
 
+func TestGithub_BuildName_FromRepository(t *testing.T) {
+	ci := &Github{Common: &Common{}, CIRepository: "owner/name", CIBuildName: "/home/runner/work/name"}
+
+	assert.Equal(t, "name", ci.BuildName())
+}
+
+// Gitea Actions checks out to /workspace/<owner>/<repository> and exports the parent of that
+// as RUNNER_WORKSPACE, so its last path element is the owner. GITHUB_REPOSITORY must win.
+func TestGithub_BuildName_FromRepository_GiteaWorkspaceLayout(t *testing.T) {
+	ci := &Github{Common: &Common{}, CIRepository: "owner/name", CIBuildName: "/workspace/owner"}
+
+	assert.Equal(t, "name", ci.BuildName())
+}
+
 func TestGithub_Override_ImageName(t *testing.T) {
-	ci := &Github{Common: &Common{}, CIBuildName: "/home/runner/work/name"}
+	ci := &Github{Common: &Common{}, CIRepository: "owner/name", CIBuildName: "/home/runner/work/name"}
 	ci.SetImageName("override")
 	assert.Equal(t, "override", ci.BuildName())
 }


### PR DESCRIPTION
The Github CI provider derived the image name from the last path element of `RUNNER_WORKSPACE`:

```go
CIBuildName string `env:"RUNNER_WORKSPACE"`

func (c *Github) BuildName() string {
	if c.CIBuildName != "" {
		return c.Common.BuildName(filepath.Base(c.CIBuildName))
	}
	...
}
```

That holds on GitHub Actions, which checks out to `/home/runner/work/<repository>`. It does not hold on Gitea Actions, which checks out to `/workspace/<owner>/<repository>` and exports the **parent** of the workspace, so the last element is the owner:

| platform | `RUNNER_WORKSPACE` | `filepath.Base` |
|---|---|---|
| GitHub Actions | `/home/runner/work/myrepo` | `myrepo` ✅ |
| Gitea Actions | `/workspace/myorg` | `myorg` ❌ |

Images were published as `<registry>/<owner>/<owner>` instead of `<registry>/<owner>/<repository>` — for us, `oci.example.com/myorg/myorg` — and every deployment referencing the expected name failed to pull with a 404.

This stayed hidden for as long as the Gitea runner left `RUNNER_WORKSPACE` unset, because the empty value fell through to `Common.BuildName("")` → `filepath.Base(cwd)`, and the working directory basename *is* the repository name. Once the runner started exporting the variable, the name changed under us with no change on our side.

`GITHUB_REPOSITORY` is `<owner>/<repository>` on both platforms and names the repository directly, so this prefers it and keeps the previous paths as fallbacks. On GitHub Actions the result is identical to before.

### Tests

Two new cases in `pkg/ci/github_test.go`: one for a GitHub-shaped workspace (asserting no behaviour change) and one for the Gitea layout, where `RUNNER_WORKSPACE` points at the owner and `GITHUB_REPOSITORY` has to win. Reverting the fix turns the Gitea case red and leaves the GitHub one green. `TestGithub_Override_ImageName` still passes, so an explicit `IMAGE_NAME` continues to beat both.
